### PR TITLE
feat: added ProjectSettings attributes to the project data source

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -21,5 +21,14 @@ description: |-
 
 ### Read-Only
 
+- `auto_cancel_builds` (Boolean)
+- `build_fork_prs` (Boolean)
+- `disable_ssh` (Boolean)
+- `forks_receive_secret_env_vars` (Boolean)
 - `id` (String) id of the circleci project
 - `name` (String) name of the circleci project
+- `oss` (Boolean)
+- `pr_only_branch_overrides` (List of String)
+- `set_github_status` (Boolean)
+- `setup_workflows` (Boolean)
+- `write_settings_requires_admin` (Boolean)

--- a/examples/data-sources/main.tf
+++ b/examples/data-sources/main.tf
@@ -21,3 +21,32 @@ output "circleci_project_slug" {
 output "circleci_project_name" {
   value = data.circleci_project.test_project.name
 }
+
+output "circleci_project_auto_cancel_builds" {
+  value = data.circleci_project.test_project.auto_cancel_builds
+}
+
+output "circleci_project_build_fork_prs" {
+  value = data.circleci_project.test_project.build_fork_prs
+}
+output "circleci_project_disable_ssh" {
+  value = data.circleci_project.test_project.disable_ssh
+}
+output "circleci_project_forks_receive_secret_env_vars" {
+  value = data.circleci_project.test_project.forks_receive_secret_env_vars
+}
+output "circleci_project_oss" {
+  value = data.circleci_project.test_project.oss
+}
+output "circleci_project_set_github_status" {
+  value = data.circleci_project.test_project.set_github_status
+}
+output "circleci_project_setup_workflows" {
+  value = data.circleci_project.test_project.setup_workflows
+}
+output "circleci_project_write_settings_requires_admin" {
+  value = data.circleci_project.test_project.write_settings_requires_admin
+}
+output "circleci_project_pr_only_branch_overrides" {
+  value = data.circleci_project.test_project.pr_only_branch_overrides
+}

--- a/internal/provider/project_data_source_test.go
+++ b/internal/provider/project_data_source_test.go
@@ -23,9 +23,9 @@ func TestAccProjectDataSource(t *testing.T) {
 				Config: testProjectDataSourceConfig,
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						"data.circleci_project.test",
-						tfjsonpath.New("id"),
-						knownvalue.StringExact("example-id"),
+						"data.circleci_project.slug",
+						tfjsonpath.New("slug"),
+						knownvalue.StringExact("circleci/8e4z1Akd74woxagxnvLT5q/V29Cenkg8EaiSZARmWm8Lz"),
 					),
 				},
 			},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -128,8 +128,7 @@ func (p *CircleCiProvider) Configure(ctx context.Context, req provider.Configure
 	projectService := project.NewProjectService(circleciClient)
 	// TODO: would it be possible to verify that the client is correctly configured?
 
-	// Make the CircleCI client available during DataSource and Resource
-	// type Configure methods.
+	// Make the CircleCI client available during DataSource and Resource type Configure methods.
 	cccw := CircleCiClientWrapper{
 		ProjectService: projectService,
 	}


### PR DESCRIPTION
Adds Project Settings to the Project data source.
(I took a look at the tests and they will work once we start creating a state, that is for resources.)
## Example main.tf
```hcl
terraform {
  required_providers {
    circleci = {
      source = "registry.terraform.io/circleci/circleci"
    }
  }
}

data "circleci_project" "test_project" {
  slug = "circleci/8e4z1Akd74woxagxnvLT5q/V29Cenkg8EaiSZARmWm8Lz"
}

output "circleci_project_id" {
  value = data.circleci_project.test_project.id
}

output "circleci_project_slug" {
  value = data.circleci_project.test_project.slug
}

output "circleci_project_name" {
  value = data.circleci_project.test_project.name
}

output "circleci_project_auto_cancel_builds" {
  value = data.circleci_project.test_project.auto_cancel_builds
}

output "circleci_project_build_fork_prs" {
  value = data.circleci_project.test_project.build_fork_prs
}
output "circleci_project_disable_ssh" {
  value = data.circleci_project.test_project.disable_ssh
}
output "circleci_project_forks_receive_secret_env_vars" {
  value = data.circleci_project.test_project.forks_receive_secret_env_vars
}
output "circleci_project_oss" {
  value = data.circleci_project.test_project.oss
}
output "circleci_project_set_github_status" {
  value = data.circleci_project.test_project.set_github_status
}
output "circleci_project_setup_workflows" {
  value = data.circleci_project.test_project.setup_workflows
}
output "circleci_project_write_settings_requires_admin" {
  value = data.circleci_project.test_project.write_settings_requires_admin
}
output "circleci_project_pr_only_branch_overrides" {
  value = data.circleci_project.test_project.pr_only_branch_overrides
}
```
## Current output
```
$ TF_LOG=ERROR terraform plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp.com/edu/hashicups in /Users/dmontano/go/bin
│  - circleci/circleci in /Users/dmontano/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may
│ cause the state to become incompatible with published releases.
╵
data.circleci_project.test_project: Reading...
data.circleci_project.test_project: Read complete after 0s [id=e2e8ae23-57dc-4e95-bc67-633fdeb4ac33]

Changes to Outputs:
  + circleci_project_auto_cancel_builds            = false
  + circleci_project_build_fork_prs                = false
  + circleci_project_disable_ssh                   = false
  + circleci_project_forks_receive_secret_env_vars = true
  + circleci_project_id                            = "e2e8ae23-57dc-4e95-bc67-633fdeb4ac33"
  + circleci_project_name                          = "test-project"
  + circleci_project_oss                           = false
  + circleci_project_pr_only_branch_overrides      = [
      + "main",
    ]
  + circleci_project_set_github_status             = true
  + circleci_project_setup_workflows               = true
  + circleci_project_slug                          = "circleci/8e4z1Akd74woxagxnvLT5q/V29Cenkg8EaiSZARmWm8Lz"
  + circleci_project_write_settings_requires_admin = false

You can apply this plan to save these new output values to the Terraform state, without changing any real
infrastructure.

─────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly
these actions if you run "terraform apply" now.
```