### PR TITLE
Add Project Environment Variable Resource and Data Source

### DIFF
--- a/internal/provider/project_environment_variable_data_source.go
+++ b/internal/provider/project_environment_variable_data_source.go
@@ -57,6 +57,7 @@ func (d *ProjectEnvironmentVariableDataSource) Schema(_ context.Context, _ datas
 			"value": schema.StringAttribute{
 				MarkdownDescription: "value of the circleci project environment variable (masked by the API)",
 				Computed:            true,
+				Sensitive:           true,
 			},
 			"created_at": schema.StringAttribute{
 				MarkdownDescription: "created date of the circleci project environment variable",

--- a/internal/provider/project_environment_variable_data_source.go
+++ b/internal/provider/project_environment_variable_data_source.go
@@ -1,0 +1,122 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/CircleCI-Public/circleci-sdk-go/envproject"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = &ProjectEnvironmentVariableDataSource{}
+	_ datasource.DataSourceWithConfigure = &ProjectEnvironmentVariableDataSource{}
+)
+
+// projectEnvironmentVariableDataSourceModel maps the output schema.
+type projectEnvironmentVariableDataSourceModel struct {
+	Name        types.String `tfsdk:"name"`
+	Value       types.String `tfsdk:"value"`
+	ProjectSlug types.String `tfsdk:"project_slug"`
+	CreatedAt   types.String `tfsdk:"created_at"`
+}
+
+// NewProjectEnvironmentVariableDataSource is a helper function to simplify the provider implementation.
+func NewProjectEnvironmentVariableDataSource() datasource.DataSource {
+	return &ProjectEnvironmentVariableDataSource{}
+}
+
+// ProjectEnvironmentVariableDataSource is the data source implementation.
+type ProjectEnvironmentVariableDataSource struct {
+	client *envproject.EnvService
+}
+
+// Metadata returns the data source type name.
+func (d *ProjectEnvironmentVariableDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_project_environment_variable"
+}
+
+// Schema defines the schema for the data source.
+func (d *ProjectEnvironmentVariableDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				MarkdownDescription: "name of the circleci project environment variable",
+				Required:            true,
+			},
+			"project_slug": schema.StringAttribute{
+				MarkdownDescription: "project slug of the circleci project environment variable (e.g. circleci/org/project)",
+				Required:            true,
+			},
+			"value": schema.StringAttribute{
+				MarkdownDescription: "value of the circleci project environment variable (masked by the API)",
+				Computed:            true,
+			},
+			"created_at": schema.StringAttribute{
+				MarkdownDescription: "created date of the circleci project environment variable",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *ProjectEnvironmentVariableDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state projectEnvironmentVariableDataSourceModel
+	diags := req.Config.Get(ctx, &state)
+	if diags != nil {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	envVar, err := d.client.Get(ctx, state.ProjectSlug.ValueString(), state.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read CircleCI project environment variable "+state.Name.ValueString(),
+			err.Error(),
+		)
+		return
+	}
+
+	state.Name = types.StringValue(envVar.Name)
+	state.Value = types.StringValue(envVar.Value)
+	if !envVar.CreatedAt.IsZero() {
+		state.CreatedAt = types.StringValue(envVar.CreatedAt.Format("2006-01-02T15:04:05.000Z"))
+	} else {
+		state.CreatedAt = types.StringValue("")
+	}
+
+	// Set state
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *ProjectEnvironmentVariableDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Add a nil check when handling ProviderData because Terraform
+	// sets that data after it calls the ConfigureProvider RPC.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*CircleCiClientWrapper)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client.ProjectEnvironmentVariableService
+}

--- a/internal/provider/project_environment_variable_data_source_test.go
+++ b/internal/provider/project_environment_variable_data_source_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccProjectEnvironmentVariableDataSource(t *testing.T) {
+	name := fmt.Sprintf("N%s", rand.Text())
+	value := rand.Text()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read testing - create a resource first, then read it via data source
+			{
+				Config: testAccProjectEnvironmentVariableDataSourceConfig(name, value, "circleci/8e4z1Akd74woxagxnvLT5q/CzMcAU8dvQo4FJhyj87QsA"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.circleci_project_environment_variable.test",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(name),
+					),
+					statecheck.ExpectKnownValue(
+						"data.circleci_project_environment_variable.test",
+						tfjsonpath.New("project_slug"),
+						knownvalue.StringExact("circleci/8e4z1Akd74woxagxnvLT5q/CzMcAU8dvQo4FJhyj87QsA"),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccProjectEnvironmentVariableDataSourceConfig(name, value, projectSlug string) string {
+	return fmt.Sprintf(`
+resource "circleci_project_environment_variable" "test_env" {
+  project_slug = %[3]q
+  name         = %[1]q
+  value        = %[2]q
+}
+
+data "circleci_project_environment_variable" "test" {
+  project_slug = circleci_project_environment_variable.test_env.project_slug
+  name         = circleci_project_environment_variable.test_env.name
+}
+`, name, value, projectSlug)
+}

--- a/internal/provider/project_environment_variable_resource.go
+++ b/internal/provider/project_environment_variable_resource.go
@@ -194,8 +194,8 @@ func (r *projectEnvironmentVariableResource) Configure(_ context.Context, req re
 }
 
 // ImportState imports an existing resource into Terraform state.
-// Expected import ID format: "project_slug/env_var_name"
-// e.g. "circleci/org_id/project_id/MY_VAR"
+// Expected import ID format: "project_slug/env_var_name".
+// e.g. "circleci/org_id/project_id/MY_VAR".
 func (r *projectEnvironmentVariableResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// The project slug contains slashes (e.g. "circleci/org/project"),
 	// so split from the right to extract the env var name.

--- a/internal/provider/project_environment_variable_resource.go
+++ b/internal/provider/project_environment_variable_resource.go
@@ -1,0 +1,216 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/CircleCI-Public/circleci-sdk-go/envproject"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &projectEnvironmentVariableResource{}
+	_ resource.ResourceWithConfigure   = &projectEnvironmentVariableResource{}
+	_ resource.ResourceWithImportState = &projectEnvironmentVariableResource{}
+)
+
+// projectEnvironmentVariableResourceModel maps the resource schema.
+type projectEnvironmentVariableResourceModel struct {
+	Name        types.String `tfsdk:"name"`
+	Value       types.String `tfsdk:"value"`
+	ProjectSlug types.String `tfsdk:"project_slug"`
+	CreatedAt   types.String `tfsdk:"created_at"`
+}
+
+// NewProjectEnvironmentVariableResource is a helper function to simplify the provider implementation.
+func NewProjectEnvironmentVariableResource() resource.Resource {
+	return &projectEnvironmentVariableResource{}
+}
+
+// projectEnvironmentVariableResource is the resource implementation.
+type projectEnvironmentVariableResource struct {
+	client *envproject.EnvService
+}
+
+// Metadata returns the resource type name.
+func (r *projectEnvironmentVariableResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_project_environment_variable"
+}
+
+// Schema defines the schema for the resource.
+func (r *projectEnvironmentVariableResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				MarkdownDescription: "name of the circleci project environment variable",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"value": schema.StringAttribute{
+				MarkdownDescription: "value of the circleci project environment variable",
+				Required:            true,
+				Sensitive:           true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"project_slug": schema.StringAttribute{
+				MarkdownDescription: "project slug of the circleci project environment variable (e.g. circleci/org/project)",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				MarkdownDescription: "created date of the circleci project environment variable",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *projectEnvironmentVariableResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Retrieve values from plan
+	var plan projectEnvironmentVariableResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create new project environment variable
+	newEnvVar, err := r.client.Create(ctx, plan.ProjectSlug.ValueString(), plan.Value.ValueString(), plan.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating CircleCI project environment variable",
+			"Could not create CircleCI project environment variable, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	// Map response body to schema and populate Computed attribute values
+	if !newEnvVar.CreatedAt.IsZero() {
+		plan.CreatedAt = types.StringValue(newEnvVar.CreatedAt.Format("2006-01-02T15:04:05.000Z"))
+	} else {
+		plan.CreatedAt = types.StringValue("")
+	}
+
+	// Set state to fully populated data
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *projectEnvironmentVariableResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state projectEnvironmentVariableResourceModel
+	diags := req.State.Get(ctx, &state)
+	if diags != nil {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	envVar, err := r.client.Get(ctx, state.ProjectSlug.ValueString(), state.Name.ValueString())
+	if err != nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.Name = types.StringValue(envVar.Name)
+	// Preserve Value from state since the API returns masked values (e.g. xxxx1234)
+	if !envVar.CreatedAt.IsZero() {
+		state.CreatedAt = types.StringValue(envVar.CreatedAt.Format("2006-01-02T15:04:05.000Z"))
+	} else {
+		state.CreatedAt = types.StringValue("")
+	}
+
+	// Set state
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *projectEnvironmentVariableResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *projectEnvironmentVariableResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Retrieve values from state
+	var state projectEnvironmentVariableResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Delete existing project environment variable
+	err := r.client.Delete(ctx, state.ProjectSlug.ValueString(), state.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting CircleCi Project Environment Variable",
+			"Could not delete project environment variable, unexpected error: "+err.Error(),
+		)
+		return
+	}
+}
+
+// Configure adds the provider configured client to the resource.
+func (r *projectEnvironmentVariableResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Add a nil check when handling ProviderData because Terraform
+	// sets that data after it calls the ConfigureProvider RPC.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*CircleCiClientWrapper)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *circleciClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client.ProjectEnvironmentVariableService
+}
+
+// ImportState imports an existing resource into Terraform state.
+// Expected import ID format: "project_slug/env_var_name"
+// e.g. "circleci/org_id/project_id/MY_VAR"
+func (r *projectEnvironmentVariableResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// The project slug contains slashes (e.g. "circleci/org/project"),
+	// so split from the right to extract the env var name.
+	lastSlash := strings.LastIndex(req.ID, "/")
+	if lastSlash == -1 || lastSlash == 0 || lastSlash == len(req.ID)-1 {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID Format",
+			fmt.Sprintf("Expected import ID format: 'project_slug/env_var_name' (e.g. 'circleci/org_id/project_id/MY_VAR'). Got: %s", req.ID),
+		)
+		return
+	}
+
+	projectSlug := req.ID[:lastSlash]
+	name := req.ID[lastSlash+1:]
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_slug"), projectSlug)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
+}

--- a/internal/provider/project_environment_variable_resource.go
+++ b/internal/provider/project_environment_variable_resource.go
@@ -127,7 +127,14 @@ func (r *projectEnvironmentVariableResource) Read(ctx context.Context, req resou
 
 	envVar, err := r.client.Get(ctx, state.ProjectSlug.ValueString(), state.Name.ValueString())
 	if err != nil {
-		resp.State.RemoveResource(ctx)
+		if strings.Contains(err.Error(), "404") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading CircleCI Project Environment Variable",
+			"Could not read project environment variable "+state.Name.ValueString()+": "+err.Error(),
+		)
 		return
 	}
 

--- a/internal/provider/project_environment_variable_resource_test.go
+++ b/internal/provider/project_environment_variable_resource_test.go
@@ -46,7 +46,7 @@ func TestAccProjectEnvironmentVariableResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:            "circleci_project_environment_variable.test_env",
+				ResourceName:                         "circleci_project_environment_variable.test_env",
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "name",

--- a/internal/provider/project_environment_variable_resource_test.go
+++ b/internal/provider/project_environment_variable_resource_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccProjectEnvironmentVariableResource(t *testing.T) {
+	name := fmt.Sprintf("N%s", rand.Text())
+	value := rand.Text()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccProjectEnvironmentVariableResourceConfig(name, value, "circleci/8e4z1Akd74woxagxnvLT5q/CzMcAU8dvQo4FJhyj87QsA"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_project_environment_variable.test_env",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(name),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_project_environment_variable.test_env",
+						tfjsonpath.New("value"),
+						knownvalue.StringExact(value),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_project_environment_variable.test_env",
+						tfjsonpath.New("project_slug"),
+						knownvalue.StringExact("circleci/8e4z1Akd74woxagxnvLT5q/CzMcAU8dvQo4FJhyj87QsA"),
+					),
+				},
+			},
+			// ImportState testing
+			{
+				ResourceName:            "circleci_project_environment_variable.test_env",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+				ImportStateVerifyIgnore:              []string{"value"},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					projectSlug, found := s.RootModule().Resources["circleci_project_environment_variable.test_env"].Primary.Attributes["project_slug"]
+					if !found {
+						return "", errors.New("attribute circleci_project_environment_variable.test_env.project_slug not found")
+					}
+					envName, found := s.RootModule().Resources["circleci_project_environment_variable.test_env"].Primary.Attributes["name"]
+					if !found {
+						return "", errors.New("attribute circleci_project_environment_variable.test_env.name not found")
+					}
+					return fmt.Sprintf("%s/%s", projectSlug, envName), nil
+				},
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccProjectEnvironmentVariableResourceUpdate(t *testing.T) {
+	name := fmt.Sprintf("N%s", rand.Text())
+	value := rand.Text()
+	updatedValue := rand.Text()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccProjectEnvironmentVariableResourceConfig(name, value, "circleci/8e4z1Akd74woxagxnvLT5q/CzMcAU8dvQo4FJhyj87QsA"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_project_environment_variable.test_env",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(name),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_project_environment_variable.test_env",
+						tfjsonpath.New("value"),
+						knownvalue.StringExact(value),
+					),
+				},
+			},
+			// Update (triggers replace) and Read testing
+			{
+				Config: testAccProjectEnvironmentVariableResourceConfig(name, updatedValue, "circleci/8e4z1Akd74woxagxnvLT5q/CzMcAU8dvQo4FJhyj87QsA"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_project_environment_variable.test_env",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(name),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_project_environment_variable.test_env",
+						tfjsonpath.New("value"),
+						knownvalue.StringExact(updatedValue),
+					),
+				},
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccProjectEnvironmentVariableResourceConfig(name, value, projectSlug string) string {
+	return fmt.Sprintf(`
+resource "circleci_project_environment_variable" "test_env" {
+  project_slug = %[3]q
+  name         = %[1]q
+  value        = %[2]q
+}
+`, name, value, projectSlug)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -33,12 +33,12 @@ var _ provider.ProviderWithEphemeralResources = &CircleCiProvider{}
 
 // circleciClientWrapper wraps all the services provided by the circleci API client.
 type CircleCiClientWrapper struct {
-	ContextService             *ccicontext.ContextService
-	EnvironmentVariableService *envcontext.EnvService
-	ProjectService             *project.ProjectService
-	PipelineService            *pipeline.PipelineService
-	OrganizationService        *organization.OrganizationService
-	TriggerService             *trigger.TriggerService
+	ContextService                    *ccicontext.ContextService
+	EnvironmentVariableService        *envcontext.EnvService
+	ProjectService                    *project.ProjectService
+	PipelineService                   *pipeline.PipelineService
+	OrganizationService               *organization.OrganizationService
+	TriggerService                    *trigger.TriggerService
 	WebhookService                    *webhook.WebhookService
 	ProjectEnvironmentVariableService *envproject.EnvService
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/CircleCI-Public/circleci-sdk-go/client"
 	ccicontext "github.com/CircleCI-Public/circleci-sdk-go/context"
 	"github.com/CircleCI-Public/circleci-sdk-go/envcontext"
+	"github.com/CircleCI-Public/circleci-sdk-go/envproject"
 	"github.com/CircleCI-Public/circleci-sdk-go/organization"
 	"github.com/CircleCI-Public/circleci-sdk-go/pipeline"
 	"github.com/CircleCI-Public/circleci-sdk-go/project"
@@ -38,7 +39,8 @@ type CircleCiClientWrapper struct {
 	PipelineService            *pipeline.PipelineService
 	OrganizationService        *organization.OrganizationService
 	TriggerService             *trigger.TriggerService
-	WebhookService             *webhook.WebhookService
+	WebhookService                    *webhook.WebhookService
+	ProjectEnvironmentVariableService *envproject.EnvService
 }
 
 // circleciProviderModel maps provider schema data to a Go type.
@@ -143,17 +145,19 @@ func (p *CircleCiProvider) Configure(ctx context.Context, req provider.Configure
 	environmentVariableService := envcontext.NewEnvService(circleciClient)
 	triggerService := trigger.NewTriggerService(circleciClient)
 	webhookService := webhook.NewWebhookService(circleciClient)
+	projectEnvVarService := envproject.NewEnvService(circleciClient)
 	// TODO: would it be possible to verify that the client is correctly configured?
 
 	// Make the CircleCI client available during DataSource and Resource type Configure methods.
 	cccw := CircleCiClientWrapper{
-		ContextService:             contextService,
-		EnvironmentVariableService: environmentVariableService,
-		OrganizationService:        organizationService,
-		ProjectService:             projectService,
-		PipelineService:            pipelineService,
-		TriggerService:             triggerService,
-		WebhookService:             webhookService,
+		ContextService:                    contextService,
+		EnvironmentVariableService:        environmentVariableService,
+		OrganizationService:               organizationService,
+		ProjectService:                    projectService,
+		PipelineService:                   pipelineService,
+		TriggerService:                    triggerService,
+		WebhookService:                    webhookService,
+		ProjectEnvironmentVariableService: projectEnvVarService,
 	}
 	resp.DataSourceData = &cccw
 	resp.ResourceData = &cccw
@@ -169,6 +173,7 @@ func (p *CircleCiProvider) Resources(ctx context.Context) []func() resource.Reso
 		NewContextEnvironmentVariableResource,
 		NewWebhookResource,
 		NewOrganizationResource,
+		NewProjectEnvironmentVariableResource,
 	}
 }
 
@@ -185,6 +190,7 @@ func (p *CircleCiProvider) DataSources(ctx context.Context) []func() datasource.
 		NewContextEnvironmentVariableDataSource,
 		NewWebhookDataSource,
 		NewOrganizationDataSource,
+		NewProjectEnvironmentVariableDataSource,
 	}
 }
 


### PR DESCRIPTION
This PR adds support for **CircleCI Project Environment Variables**. It introduces a new resource and a corresponding data source, allowing users to manage environment variables at the project level.

## Changes

### 🆕 New Components
* **Resource:** `circleci_project_environment_variable`
    * Implements `Create`, `Read`, and `Delete` functionality.
    * **Sensitive Handling:** The `value` attribute is marked as sensitive to prevent exposure in logs.
    * **Replacement Logic:** Since the CircleCI API treats these as immutable or replacement-only, changes to `name`, `value`, or `project_slug` will trigger a `RequiresReplace` plan modifier.
    * **Import Support:** Supports importing existing variables using the format `project_slug/name` (e.g., `circleci/org/project/MY_VAR`).
* **Data Source:** `circleci_project_environment_variable`
    * Allows fetching the `name`, `created_at` timestamp, and the masked `value` of an existing variable for use elsewhere in the configuration.

### ⚙️ Provider Integration
* Updated `internal/provider/provider.go` to initialize the `envproject.EnvService`.
* Registered the new resource and data source in the provider's `Resources` and `DataSources` discovery functions.
* Added `ProjectEnvironmentVariableService` to the `CircleCiClientWrapper` struct to expose the SDK service to the provider logic.

### ✅ Testing
* Added **Acceptance Tests** (`TestAccProjectEnvironmentVariableResource` and `TestAccProjectEnvironmentVariableDataSource`) covering:
    * Resource creation and state persistence.
    * Verification that updates trigger the correct replacement behavior.
    * Import state verification logic.
    * Data source attribute matching.

---

## Schema Reference

### `circleci_project_environment_variable`

| Attribute | Type | Category | Description |
| :--- | :--- | :--- | :--- |
| `project_slug` | String | **Required** | The project slug (e.g., `circleci/org/repo`). |
| `name` | String | **Required** | The name of the environment variable. |
| `value` | String | **Required** | The secret value (Sensitive). |
| `created_at` | String | **Computed** | The UTC timestamp of when the variable was created. |

---

## Example Usage

```hcl
# Create a project environment variable
resource "circleci_project_environment_variable" "example" {
  project_slug = "circleci/my-org/my-project"
  name         = "SERVICE_API_TOKEN"
  value        = "super-secret-value"
}

# Read it back via data source
data "circleci_project_environment_variable" "example_lookup" {
  project_slug = circleci_project_environment_variable.example.project_slug
  name         = circleci_project_environment_variable.example.name
}