### PR TITLE
Add runner resource class, token resource, and resource class data source

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/runner_resources.md
+++ b/.github/PULL_REQUEST_TEMPLATE/runner_resources.md
@@ -1,0 +1,63 @@
+## Summary
+
+<!-- Briefly describe what runner infrastructure this PR adds or changes. -->
+
+## Changes
+
+### New Components
+
+<!-- List each new resource, data source, or ephemeral resource. For each one include:
+     - The Terraform type name (e.g. `circleci_runner_token`)
+     - CRUD operations implemented
+     - Any notable behaviour (write-once fields, force-delete, etc.)
+     - Import support and the import ID format -->
+
+### Provider Integration
+
+<!-- Confirm provider.go changes:
+     - New SDK service field added to CircleCiClientWrapper
+     - Service initialized in Configure()
+     - Resource/data source registered in Resources() or DataSources() -->
+
+### SDK Dependency
+
+<!-- Does this require the local circleci-sdk-go replace directive in go.mod?
+     If so, note which package(s) and when they are expected to be published remotely. -->
+
+## Schema Reference
+
+<!-- Add a table for each new resource/data source. -->
+
+### `circleci_runner_<name>`
+
+| Attribute | Type | Category | Description |
+| :--- | :--- | :--- | :--- |
+| `id` | String | Computed | UUID assigned by the API |
+| | | | |
+
+## Example Usage
+
+```hcl
+resource "circleci_runner_resource_class" "example" {
+  resource_class = "myorg/myrunner"
+  description    = "My self-hosted runner"
+}
+
+resource "circleci_runner_token" "example" {
+  resource_class = circleci_runner_resource_class.example.resource_class
+  nickname       = "my-agent-token"
+}
+```
+
+## Testing
+
+- [ ] `go build ./...` passes
+- [ ] Acceptance tests require a CircleCI token with **self-hosted runner admin** permissions (separate scope from the standard `CIRCLE_TOKEN` used by other tests)
+- [ ] `TF_ACC=1 CIRCLE_TOKEN=<runner-admin-token> go test ./internal/provider/ -run TestAccRunner -v -timeout 120s`
+- [ ] Create and Read verified against live API
+- [ ] Delete (and force-delete if applicable) verified
+- [ ] ImportState verified
+
+## Notes
+
+<!-- Anything reviewers should be aware of — API quirks, missing endpoints, known limitations. -->

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.24.0
 
 toolchain go1.24.1
 
+replace github.com/CircleCI-Public/circleci-sdk-go => ../circleci-sdk-go
+
 require (
 	github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260211170335-ae5afa2800da
 	github.com/hashicorp/terraform-plugin-framework v1.16.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260211170335-ae5afa2800da h1:9zHayfSbGqGXBmQ/ip7QnDTxyghIW64URLlSDwg15Bo=
-github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260211170335-ae5afa2800da/go.mod h1:ktaOvVE5su0XsQYEiO+VoYn3pfnuiN4CrUdFsJy7Q0c=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rWPdisA5ynNEsoARbiCBOyGcJM4/OzsM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.1 h1:Sz1JIXEcSfhz7fUi7xHnhpIE0thVASYjvosApmHuD2k=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/CircleCI-Public/circleci-sdk-go/organization"
 	"github.com/CircleCI-Public/circleci-sdk-go/pipeline"
 	"github.com/CircleCI-Public/circleci-sdk-go/project"
+	"github.com/CircleCI-Public/circleci-sdk-go/runner"
 	"github.com/CircleCI-Public/circleci-sdk-go/trigger"
 	"github.com/CircleCI-Public/circleci-sdk-go/webhook"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -41,6 +42,7 @@ type CircleCiClientWrapper struct {
 	TriggerService                    *trigger.TriggerService
 	WebhookService                    *webhook.WebhookService
 	ProjectEnvironmentVariableService *envproject.EnvService
+	RunnerService                     *runner.Service
 }
 
 // circleciProviderModel maps provider schema data to a Go type.
@@ -146,6 +148,7 @@ func (p *CircleCiProvider) Configure(ctx context.Context, req provider.Configure
 	triggerService := trigger.NewTriggerService(circleciClient)
 	webhookService := webhook.NewWebhookService(circleciClient)
 	projectEnvVarService := envproject.NewEnvService(circleciClient)
+	runnerService := runner.NewService(circleciClient)
 	// TODO: would it be possible to verify that the client is correctly configured?
 
 	// Make the CircleCI client available during DataSource and Resource type Configure methods.
@@ -158,6 +161,7 @@ func (p *CircleCiProvider) Configure(ctx context.Context, req provider.Configure
 		TriggerService:                    triggerService,
 		WebhookService:                    webhookService,
 		ProjectEnvironmentVariableService: projectEnvVarService,
+		RunnerService:                     runnerService,
 	}
 	resp.DataSourceData = &cccw
 	resp.ResourceData = &cccw
@@ -174,6 +178,8 @@ func (p *CircleCiProvider) Resources(ctx context.Context) []func() resource.Reso
 		NewWebhookResource,
 		NewOrganizationResource,
 		NewProjectEnvironmentVariableResource,
+		NewRunnerResourceClassResource,
+		NewRunnerTokenResource,
 	}
 }
 
@@ -191,6 +197,7 @@ func (p *CircleCiProvider) DataSources(ctx context.Context) []func() datasource.
 		NewWebhookDataSource,
 		NewOrganizationDataSource,
 		NewProjectEnvironmentVariableDataSource,
+		NewRunnerResourceClassDataSource,
 	}
 }
 

--- a/internal/provider/runner_resource_class_data_source.go
+++ b/internal/provider/runner_resource_class_data_source.go
@@ -1,0 +1,135 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/CircleCI-Public/circleci-sdk-go/runner"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = &runnerResourceClassDataSource{}
+	_ datasource.DataSourceWithConfigure = &runnerResourceClassDataSource{}
+)
+
+// runnerResourceClassDataSourceModel maps the data source schema.
+type runnerResourceClassDataSourceModel struct {
+	ResourceClass types.String `tfsdk:"resource_class"`
+	Id            types.String `tfsdk:"id"`
+	Description   types.String `tfsdk:"description"`
+}
+
+// NewRunnerResourceClassDataSource is a helper function to simplify the provider implementation.
+func NewRunnerResourceClassDataSource() datasource.DataSource {
+	return &runnerResourceClassDataSource{}
+}
+
+// runnerResourceClassDataSource is the data source implementation.
+type runnerResourceClassDataSource struct {
+	client *runner.Service
+}
+
+// Metadata returns the data source type name.
+func (d *runnerResourceClassDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_runner_resource_class"
+}
+
+// Schema defines the schema for the data source.
+func (d *runnerResourceClassDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Reads a CircleCI runner resource class.",
+		Attributes: map[string]schema.Attribute{
+			"resource_class": schema.StringAttribute{
+				MarkdownDescription: "The resource class name in `namespace/name` format (e.g. `myorg/myrunner`).",
+				Required:            true,
+			},
+			"id": schema.StringAttribute{
+				MarkdownDescription: "Unique identifier (UUID) of the runner resource class.",
+				Computed:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description of the runner resource class.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+// Read fetches the resource class from the API.
+func (d *runnerResourceClassDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state runnerResourceClassDataSourceModel
+	diags := req.Config.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	rcName := state.ResourceClass.ValueString()
+	slashIdx := strings.Index(rcName, "/")
+	if slashIdx == -1 {
+		resp.Diagnostics.AddError(
+			"Invalid resource_class format",
+			fmt.Sprintf("Expected namespace/name format, got: %s", rcName),
+		)
+		return
+	}
+	namespace := rcName[:slashIdx]
+
+	classes, err := d.client.ListResourceClasses(ctx, namespace, "")
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading CircleCI runner resource classes",
+			"Could not list runner resource classes for namespace "+namespace+": "+err.Error(),
+		)
+		return
+	}
+
+	var found *runner.ResourceClass
+	for i := range classes {
+		if classes[i].ResourceClass == rcName {
+			found = &classes[i]
+			break
+		}
+	}
+
+	if found == nil {
+		resp.Diagnostics.AddError(
+			"Runner resource class not found",
+			fmt.Sprintf("No runner resource class with name %q was found in namespace %q.", rcName, namespace),
+		)
+		return
+	}
+
+	state.Id = types.StringValue(found.Id)
+	state.ResourceClass = types.StringValue(found.ResourceClass)
+	state.Description = types.StringValue(found.Description)
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *runnerResourceClassDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*CircleCiClientWrapper)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *CircleCiClientWrapper, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client.RunnerService
+}

--- a/internal/provider/runner_resource_class_data_source_test.go
+++ b/internal/provider/runner_resource_class_data_source_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,6 +24,9 @@ func TestAccRunnerResourceClassDataSource(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
+			// Create a resource class then read it back via the data source.
+			// Verifies all three attributes and that the data source id matches
+			// the resource id.
 			{
 				Config: testAccRunnerResourceClassDataSourceConfig(resourceClass, description),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -41,7 +45,41 @@ func TestAccRunnerResourceClassDataSource(t *testing.T) {
 						tfjsonpath.New("id"),
 						knownvalue.StringRegexp(uuidRegex),
 					),
+					// Data source id must equal the resource id.
+					statecheck.CompareValuePairs(
+						"circleci_runner_resource_class.test",
+						tfjsonpath.New("id"),
+						"data.circleci_runner_resource_class.test",
+						tfjsonpath.New("id"),
+						compare.ValuesSame(),
+					),
 				},
+			},
+		},
+	})
+}
+
+func TestAccRunnerResourceClassDataSourceNotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRunnerResourceClassDataSourceOnlyConfig("cci-terraform-test/does-not-exist-acc"),
+				ExpectError: regexp.MustCompile(`Runner resource class not found`),
+			},
+		},
+	})
+}
+
+func TestAccRunnerResourceClassDataSourceInvalidFormat(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRunnerResourceClassDataSourceOnlyConfig("noslash"),
+				ExpectError: regexp.MustCompile(`Invalid resource_class format`),
 			},
 		},
 	})
@@ -58,4 +96,12 @@ data "circleci_runner_resource_class" "test" {
   resource_class = circleci_runner_resource_class.test.resource_class
 }
 `, resourceClass, description)
+}
+
+func testAccRunnerResourceClassDataSourceOnlyConfig(resourceClass string) string {
+	return fmt.Sprintf(`
+data "circleci_runner_resource_class" "test" {
+  resource_class = %[1]q
+}
+`, resourceClass)
 }

--- a/internal/provider/runner_resource_class_data_source_test.go
+++ b/internal/provider/runner_resource_class_data_source_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccRunnerResourceClassDataSource(t *testing.T) {
+	resourceClass := "cci-terraform-test/acc-test-runner-ds"
+	description := "Acceptance test runner resource class data source"
+	uuidRegex := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRunnerResourceClassDataSourceConfig(resourceClass, description),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.circleci_runner_resource_class.test",
+						tfjsonpath.New("resource_class"),
+						knownvalue.StringExact(resourceClass),
+					),
+					statecheck.ExpectKnownValue(
+						"data.circleci_runner_resource_class.test",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact(description),
+					),
+					statecheck.ExpectKnownValue(
+						"data.circleci_runner_resource_class.test",
+						tfjsonpath.New("id"),
+						knownvalue.StringRegexp(uuidRegex),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccRunnerResourceClassDataSourceConfig(resourceClass, description string) string {
+	return fmt.Sprintf(`
+resource "circleci_runner_resource_class" "test" {
+  resource_class = %[1]q
+  description    = %[2]q
+}
+
+data "circleci_runner_resource_class" "test" {
+  resource_class = circleci_runner_resource_class.test.resource_class
+}
+`, resourceClass, description)
+}

--- a/internal/provider/runner_resource_class_resource.go
+++ b/internal/provider/runner_resource_class_resource.go
@@ -1,0 +1,217 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/CircleCI-Public/circleci-sdk-go/runner"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &runnerResourceClassResource{}
+	_ resource.ResourceWithConfigure   = &runnerResourceClassResource{}
+	_ resource.ResourceWithImportState = &runnerResourceClassResource{}
+)
+
+// runnerResourceClassResourceModel maps the resource schema.
+type runnerResourceClassResourceModel struct {
+	Id            types.String `tfsdk:"id"`
+	ResourceClass types.String `tfsdk:"resource_class"`
+	Description   types.String `tfsdk:"description"`
+	ForceDelete   types.Bool   `tfsdk:"force_delete"`
+}
+
+// NewRunnerResourceClassResource is a helper function to simplify the provider implementation.
+func NewRunnerResourceClassResource() resource.Resource {
+	return &runnerResourceClassResource{}
+}
+
+// runnerResourceClassResource is the resource implementation.
+type runnerResourceClassResource struct {
+	client *runner.Service
+}
+
+// Metadata returns the resource type name.
+func (r *runnerResourceClassResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_runner_resource_class"
+}
+
+// Schema defines the schema for the resource.
+func (r *runnerResourceClassResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages a CircleCI runner resource class.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "Unique identifier (UUID) of the runner resource class.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"resource_class": schema.StringAttribute{
+				MarkdownDescription: "The resource class name in `namespace/name` format (e.g. `myorg/myrunner`).",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description of the runner resource class.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"force_delete": schema.BoolAttribute{
+				MarkdownDescription: "If true, deletes the resource class even if it has associated tokens.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *runnerResourceClassResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan runnerResourceClassResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createReq := runner.CreateResourceClassRequest{
+		ResourceClass: plan.ResourceClass.ValueString(),
+		Description:   plan.Description.ValueString(),
+	}
+
+	rc, err := r.client.CreateResourceClass(ctx, createReq)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating CircleCI runner resource class",
+			"Could not create runner resource class, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	plan.Id = types.StringValue(rc.Id)
+	plan.ResourceClass = types.StringValue(rc.ResourceClass)
+	plan.Description = types.StringValue(rc.Description)
+
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *runnerResourceClassResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state runnerResourceClassResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	rcName := state.ResourceClass.ValueString()
+	slashIdx := strings.Index(rcName, "/")
+	if slashIdx == -1 {
+		resp.Diagnostics.AddError(
+			"Invalid resource_class format",
+			fmt.Sprintf("Expected namespace/name format, got: %s", rcName),
+		)
+		return
+	}
+	namespace := rcName[:slashIdx]
+
+	classes, err := r.client.ListResourceClasses(ctx, namespace, "")
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading CircleCI runner resource classes",
+			"Could not list runner resource classes for namespace "+namespace+": "+err.Error(),
+		)
+		return
+	}
+
+	var found *runner.ResourceClass
+	for i := range classes {
+		if classes[i].ResourceClass == rcName {
+			found = &classes[i]
+			break
+		}
+	}
+
+	if found == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.Id = types.StringValue(found.Id)
+	state.ResourceClass = types.StringValue(found.ResourceClass)
+	state.Description = types.StringValue(found.Description)
+	// ForceDelete is not returned by the API — preserve value from state.
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Update updates the resource. All mutable fields require replacement, so this is a no-op.
+func (r *runnerResourceClassResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *runnerResourceClassResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state runnerResourceClassResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteResourceClass(ctx, state.Id.ValueString(), state.ForceDelete.ValueBool())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting CircleCI runner resource class",
+			"Could not delete runner resource class "+state.Id.ValueString()+": "+err.Error(),
+		)
+	}
+}
+
+// Configure adds the provider configured client to the resource.
+func (r *runnerResourceClassResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*CircleCiClientWrapper)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *CircleCiClientWrapper, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client.RunnerService
+}
+
+// ImportState imports an existing resource class into Terraform state.
+// The import ID is the resource_class string (e.g. "myorg/myrunner").
+// After import, Read is called to populate the full state.
+func (r *runnerResourceClassResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("resource_class"), req.ID)...)
+}

--- a/internal/provider/runner_resource_class_resource_test.go
+++ b/internal/provider/runner_resource_class_resource_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccRunnerResourceClassResource(t *testing.T) {
+	resourceClass := "cci-terraform-test/acc-test-runner"
+	description := "Acceptance test runner resource class"
+	uuidRegex := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccRunnerResourceClassConfig(resourceClass, description, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_runner_resource_class.test",
+						tfjsonpath.New("resource_class"),
+						knownvalue.StringExact(resourceClass),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_runner_resource_class.test",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact(description),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_runner_resource_class.test",
+						tfjsonpath.New("id"),
+						knownvalue.StringRegexp(uuidRegex),
+					),
+				},
+			},
+			// ImportState testing
+			{
+				ResourceName:            "circleci_runner_resource_class.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_delete"},
+				ImportStateId:           resourceClass,
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccRunnerResourceClassForceDelete(t *testing.T) {
+	resourceClass := "cci-terraform-test/acc-test-runner-force"
+	description := "Acceptance test runner resource class with force delete"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with force_delete = true
+			{
+				Config: testAccRunnerResourceClassConfig(resourceClass, description, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_runner_resource_class.test",
+						tfjsonpath.New("resource_class"),
+						knownvalue.StringExact(resourceClass),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_runner_resource_class.test",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact(description),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_runner_resource_class.test",
+						tfjsonpath.New("force_delete"),
+						knownvalue.Bool(true),
+					),
+				},
+			},
+			// Delete testing automatically occurs in TestCase (exercises force-delete path)
+		},
+	})
+}
+
+func testAccRunnerResourceClassConfig(resourceClass, description string, forceDelete bool) string {
+	return fmt.Sprintf(`
+resource "circleci_runner_resource_class" "test" {
+  resource_class = %[1]q
+  description    = %[2]q
+  force_delete   = %[3]t
+}
+`, resourceClass, description, forceDelete)
+}

--- a/internal/provider/runner_token_resource.go
+++ b/internal/provider/runner_token_resource.go
@@ -1,0 +1,230 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/CircleCI-Public/circleci-sdk-go/runner"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &runnerTokenResource{}
+	_ resource.ResourceWithConfigure   = &runnerTokenResource{}
+	_ resource.ResourceWithImportState = &runnerTokenResource{}
+)
+
+// runnerTokenResourceModel maps the resource schema.
+type runnerTokenResourceModel struct {
+	Id            types.String `tfsdk:"id"`
+	ResourceClass types.String `tfsdk:"resource_class"`
+	Nickname      types.String `tfsdk:"nickname"`
+	Token         types.String `tfsdk:"token"`
+	CreatedAt     types.String `tfsdk:"created_at"`
+}
+
+// NewRunnerTokenResource is a helper function to simplify the provider implementation.
+func NewRunnerTokenResource() resource.Resource {
+	return &runnerTokenResource{}
+}
+
+// runnerTokenResource is the resource implementation.
+type runnerTokenResource struct {
+	client *runner.Service
+}
+
+// Metadata returns the resource type name.
+func (r *runnerTokenResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_runner_token"
+}
+
+// Schema defines the schema for the resource.
+func (r *runnerTokenResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages a CircleCI runner authentication token. The token value is only available at creation time and cannot be retrieved afterwards.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "Unique identifier (UUID) of the runner token.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"resource_class": schema.StringAttribute{
+				MarkdownDescription: "The resource class this token grants access to, in `namespace/name` format (e.g. `myorg/myrunner`).",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"nickname": schema.StringAttribute{
+				MarkdownDescription: "A human-readable label for the token.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"token": schema.StringAttribute{
+				MarkdownDescription: "The token value used to authenticate a runner agent. Only available at creation time — this value is not returned by the API on subsequent reads and will be empty after an import.",
+				Computed:            true,
+				Sensitive:           true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				MarkdownDescription: "The time at which the token was created.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *runnerTokenResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan runnerTokenResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createReq := runner.CreateTokenRequest{
+		ResourceClass: plan.ResourceClass.ValueString(),
+		Nickname:      plan.Nickname.ValueString(),
+	}
+
+	t, err := r.client.CreateToken(ctx, createReq)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating CircleCI runner token",
+			"Could not create runner token, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	plan.Id = types.StringValue(t.Id)
+	plan.ResourceClass = types.StringValue(t.ResourceClass)
+	plan.Nickname = types.StringValue(t.Nickname)
+	plan.Token = types.StringValue(t.Token)
+	plan.CreatedAt = types.StringValue(t.CreatedAt)
+
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *runnerTokenResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state runnerTokenResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tokens, err := r.client.ListTokens(ctx, state.ResourceClass.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading CircleCI runner tokens",
+			"Could not list runner tokens for resource class "+state.ResourceClass.ValueString()+": "+err.Error(),
+		)
+		return
+	}
+
+	var found *runner.Token
+	for i := range tokens {
+		if tokens[i].Id == state.Id.ValueString() {
+			found = &tokens[i]
+			break
+		}
+	}
+
+	if found == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.Id = types.StringValue(found.Id)
+	state.ResourceClass = types.StringValue(found.ResourceClass)
+	state.Nickname = types.StringValue(found.Nickname)
+	state.CreatedAt = types.StringValue(found.CreatedAt)
+	// Token is write-once and not returned by the API — preserve value from state.
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Update updates the resource. All fields require replacement, so this is a no-op.
+func (r *runnerTokenResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *runnerTokenResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state runnerTokenResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteToken(ctx, state.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting CircleCI runner token",
+			"Could not delete runner token "+state.Id.ValueString()+": "+err.Error(),
+		)
+	}
+}
+
+// Configure adds the provider configured client to the resource.
+func (r *runnerTokenResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*CircleCiClientWrapper)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *CircleCiClientWrapper, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client.RunnerService
+}
+
+// ImportState imports an existing runner token into Terraform state.
+// The import ID format is "resource_class/token_id" (e.g. "myorg/myrunner/550e8400-...").
+// Note: the token value cannot be recovered after import.
+func (r *runnerTokenResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// resource_class is "namespace/name" (one slash), token_id is a UUID (no slashes).
+	// Split on the last slash to separate them.
+	lastSlash := strings.LastIndex(req.ID, "/")
+	if lastSlash == -1 || lastSlash == 0 || lastSlash == len(req.ID)-1 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID format",
+			fmt.Sprintf("Expected format: resource_class/token_id (e.g. myorg/myrunner/550e8400-...). Got: %s", req.ID),
+		)
+		return
+	}
+
+	resourceClass := req.ID[:lastSlash]
+	tokenID := req.ID[lastSlash+1:]
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("resource_class"), resourceClass)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), tokenID)...)
+}

--- a/internal/provider/runner_token_resource_test.go
+++ b/internal/provider/runner_token_resource_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccRunnerTokenResource(t *testing.T) {
+	resourceClass := "cci-terraform-test/acc-test-runner"
+	nickname := "acc-test-token"
+	uuidRegex := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccRunnerTokenConfig(resourceClass, nickname),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_runner_token.test",
+						tfjsonpath.New("resource_class"),
+						knownvalue.StringExact(resourceClass),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_runner_token.test",
+						tfjsonpath.New("nickname"),
+						knownvalue.StringExact(nickname),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_runner_token.test",
+						tfjsonpath.New("id"),
+						knownvalue.StringRegexp(uuidRegex),
+					),
+					// token is sensitive but should be non-empty after create
+					statecheck.ExpectKnownValue(
+						"circleci_runner_token.test",
+						tfjsonpath.New("token"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+			// ImportState testing — token value will be empty after import since it's write-once
+			{
+				ResourceName:            "circleci_runner_token.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"token"},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rc, found := s.RootModule().Resources["circleci_runner_token.test"].Primary.Attributes["resource_class"]
+					if !found {
+						return "", errors.New("attribute resource_class not found")
+					}
+					id, found := s.RootModule().Resources["circleci_runner_token.test"].Primary.Attributes["id"]
+					if !found {
+						return "", errors.New("attribute id not found")
+					}
+					return fmt.Sprintf("%s/%s", rc, id), nil
+				},
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccRunnerTokenConfig(resourceClass, nickname string) string {
+	return fmt.Sprintf(`
+resource "circleci_runner_token" "test" {
+  resource_class = %[1]q
+  nickname       = %[2]q
+}
+`, resourceClass, nickname)
+}


### PR DESCRIPTION
## Summary

Adds Terraform support for managing CircleCI self-hosted runner infrastructure: resource classes (the named pool a runner connects to) and authentication tokens (the credentials a runner agent uses to identify itself).

## Changes

### New Components

- **`circleci_runner_resource_class`** (resource)
  - Create, Delete, ImportState
  - `force_delete` flag hits a separate API endpoint (`/resource/{id}/force`) to remove a class even when tokens are still attached
  - Read uses list-and-match: no get-by-ID endpoint exists, so the namespace is extracted from `resource_class` and `ListResourceClasses` is scanned for an exact name match
  - Import ID: `resource_class` string (e.g. `myorg/myrunner`)

- **`circleci_runner_token`** (resource)
  - Create, Delete, ImportState
  - `token` is write-once — only returned by the API on create, never on subsequent reads; stored as sensitive in state and preserved across refreshes
  - `token` will be empty after import since it cannot be recovered
  - Import ID: `resource_class/token_id` (e.g. `myorg/myrunner/550e8400-...`), split on the last `/`

- **`circleci_runner_resource_class`** (data source)
  - Reads an existing resource class by `resource_class` name
  - Returns `id` and `description`
  - Errors (rather than silently removing state) when the resource class is not found, which is the correct behaviour for a data source

### Provider Integration

- `RunnerService *runner.Service` added to `CircleCiClientWrapper`
- `runner.NewService(circleciClient)` initialized in `Configure()`
- `NewRunnerResourceClassResource` and `NewRunnerTokenResource` registered in `Resources()`
- `NewRunnerResourceClassDataSource` registered in `DataSources()`

### SDK Dependency

Yes — the `runner` package is not yet published in the remote `circleci-sdk-go` module. A `replace` directive in `go.mod` points at the local checkout:

```
replace github.com/CircleCI-Public/circleci-sdk-go => ../circleci-sdk-go
```

This can be removed once the runner package is included in a published release of the SDK.

## Schema Reference

### `circleci_runner_resource_class`

| Attribute | Type | Category | Description |
| :--- | :--- | :--- | :--- |
| `id` | String | Computed | UUID assigned by the API |
| `resource_class` | String | Required | Name in `namespace/name` format; RequiresReplace |
| `description` | String | Optional+Computed | Human-readable description; UseStateForUnknown |
| `force_delete` | Bool | Optional+Computed | Delete even if tokens exist; UseStateForUnknown |

### `circleci_runner_token`

| Attribute | Type | Category | Description |
| :--- | :--- | :--- | :--- |
| `id` | String | Computed | UUID assigned by the API |
| `resource_class` | String | Required | Resource class this token grants access to; RequiresReplace |
| `nickname` | String | Required | Human-readable label; RequiresReplace |
| `token` | String | Computed+Sensitive | Write-once auth token; only available at creation time |
| `created_at` | String | Computed | Creation timestamp |

## Example Usage

```hcl
resource "circleci_runner_resource_class" "example" {
  resource_class = "myorg/myrunner"
  description    = "My self-hosted runner"
}

resource "circleci_runner_token" "example" {
  resource_class = circleci_runner_resource_class.example.resource_class
  nickname       = "my-agent-token"
}

data "circleci_runner_resource_class" "lookup" {
  resource_class = "myorg/myrunner"
}
```

## Testing

- [x] `go build ./...` passes
- [ ] Acceptance tests require a CircleCI token with **self-hosted runner admin** permissions (separate scope from the standard `CIRCLE_TOKEN` used by other tests)
- [ ] `TF_ACC=1 CIRCLE_TOKEN=<runner-admin-token> go test ./internal/provider/ -run TestAccRunner -v -timeout 120s`
- [ ] Create and Read verified against live API
- [ ] Delete (and force-delete if applicable) verified
- [ ] ImportState verified

## Notes

- The runner API lives at `https://runner.circleci.com` — a completely separate base URL from the main CircleCI API at `circleci.com/api/v2`. The `runner.NewService` constructor hardcodes this.
- Acceptance tests will fail with a `404 not found with provided token: check permissions to view or admin self-hosted runners` error if the token lacks runner admin scope — this is a permissions issue, not a code bug.