### PR TITLE
fix resource class import so that the organization_id update does not require a recreation of the resource_class

### DIFF
--- a/internal/provider/runner_resource_class_resource.go
+++ b/internal/provider/runner_resource_class_resource.go
@@ -64,9 +64,6 @@ func (r *runnerResourceClassResource) Schema(_ context.Context, _ resource.Schem
 			"organization_id": schema.StringAttribute{
 				MarkdownDescription: "The organization id.",
 				Required:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"resource_class": schema.StringAttribute{
 				MarkdownDescription: "The resource class name in `namespace/name` format (e.g. `myorg/myrunner`).",

--- a/internal/provider/runner_resource_class_resource_test.go
+++ b/internal/provider/runner_resource_class_resource_test.go
@@ -53,6 +53,17 @@ func TestAccRunnerResourceClassResource(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"force_delete", "organization_id"}, // force_delete is not stored in API, organization_id is not importable
 				ImportStateId:           resourceClass,
 			},
+			// Update after import testing
+			{
+				Config: testAccRunnerResourceClassConfig(organizationId, resourceClass, description, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_runner_resource_class.test",
+						tfjsonpath.New("organization_id"),
+						knownvalue.StringExact(organizationId),
+					),
+				},
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})


### PR DESCRIPTION
# Description
Modified the `circleci_runner_resource_class` resource to remove the `RequiresReplace` constraint from the `organization_id` attribute. Also added an acceptance test step to verify that the state can be correctly updated/verified after an import operation.

# Reasons
* **Flexible State Management:** Removing `RequiresReplace` prevents Terraform from unnecessarily destroying and recreating a runner resource class when the `organization_id` is provided or adjusted in the configuration, particularly during the transition from an unmanaged to a managed state.
* **Improved Import Workflow:** This change facilitates a smoother `terraform import` experience. Since `organization_id` is not always returnable via the specific import ID, allowing the field to be updated in-place ensures the local state can be reconciled with the actual infrastructure without resource churn.
* **Test Coverage:** Added a post-import configuration check in the acceptance tests to ensure the `organization_id` is correctly persisted and recognized in the state.
