### PR TITLE
fix: updating goreleaser logic to skip windows/arm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 version: 2
@@ -31,9 +29,12 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats:
+  - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:


### PR DESCRIPTION
# Description
Updated the `.goreleaser.yml` configuration to prune the build matrix and modernize the archive format specification.

### Key Changes:
* **Build Matrix Pruning:** Added an ignore rule for `windows/arm` builds.
* **Archive Configuration:** Refactored the `archives` section to use the `formats` (plural) key, supporting multiple archive types.
* **Cleanup:** Removed a stale HashiCorp copyright header from the configuration file.

# Reasons
* **Binary Distribution:** Terraform providers generally do not support `windows/arm` (32-bit), so removing this target reduces build time and prevents the distribution of unsupported binaries.
* **GoReleaser V2 Compatibility:** The switch to `formats: [zip]` aligns the configuration with the latest GoReleaser schema conventions.
* **Build Efficiency:** Streamlining the ignore list ensures that the CI/CD pipeline only produces artifacts for relevant, supported architectures.
