### PR TITLE
Persist runner_resource_class plan on update

### DIFF
--- a/internal/provider/runner_resource_class_resource.go
+++ b/internal/provider/runner_resource_class_resource.go
@@ -174,8 +174,18 @@ func (r *runnerResourceClassResource) Read(ctx context.Context, req resource.Rea
 	resp.Diagnostics.Append(diags...)
 }
 
-// Update updates the resource. All mutable fields require replacement, so this is a no-op.
-func (r *runnerResourceClassResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
+// Update persists plan values (such as organization_id and force_delete) into
+// state. The runner API has no update endpoint, so no API call is made.
+func (r *runnerResourceClassResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan runnerResourceClassResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = resp.State.Set(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
 }
 
 // Delete deletes the resource and removes the Terraform state on success.


### PR DESCRIPTION
When applying or importing a circleci_runner_resource_class with organization_id set, the apply succeeds but Terraform returns the following error:
```
Error: Provider produced inconsistent result after apply

.organization_id: was cty.StringVal("08d0db1e-...") but now null
```

The issue here is that we have a no-op update in the runner_resource_class because all the mutable fields used to be RequiresReplace which we had removed recently. Therefore update can be called, so it must be implemented.

Solution is to just persist the plan to state on update so that the provider produces a consistent result after apply.