### PR TITLE
feat: add github_server provider support (SC-3101)

### DIFF
--- a/examples/resources/circleci_trigger/github_server.tf
+++ b/examples/resources/circleci_trigger/github_server.tf
@@ -4,7 +4,5 @@ resource "circleci_trigger" "github_server_example" {
   event_source_provider         = "github_server"
   event_source_repo_external_id = "2259"
   event_preset                  = "all-pushes"
-  checkout_ref                  = "main"
-  config_ref                    = "main"
   disabled                      = false
 }

--- a/examples/resources/circleci_trigger/github_server.tf
+++ b/examples/resources/circleci_trigger/github_server.tf
@@ -1,8 +1,8 @@
 resource "circleci_trigger" "github_server_example" {
-  project_id                    = "61169e84-93ee-415d-8d65-ddf6dc0d2939"
-  pipeline_id                   = "fefb451c-9966-4b75-b555-d4d94d7116ef"
+  project_id                    = "20209578-aa1c-4b4c-9ca5-f6e38a47cf73"
+  pipeline_id                   = "9c7c4e85-5022-41d0-a6b0-705cfa856485"
   event_source_provider         = "github_server"
-  event_source_repo_external_id = "952038793"
+  event_source_repo_external_id = "2259"
   event_preset                  = "all-pushes"
   checkout_ref                  = "main"
   config_ref                    = "main"

--- a/examples/resources/circleci_trigger/github_server.tf
+++ b/examples/resources/circleci_trigger/github_server.tf
@@ -1,0 +1,10 @@
+resource "circleci_trigger" "github_server_example" {
+  project_id                    = "61169e84-93ee-415d-8d65-ddf6dc0d2939"
+  pipeline_id                   = "fefb451c-9966-4b75-b555-d4d94d7116ef"
+  event_source_provider         = "github_server"
+  event_source_repo_external_id = "952038793"
+  event_preset                  = "all-pushes"
+  checkout_ref                  = "main"
+  config_ref                    = "main"
+  disabled                      = false
+}

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -87,10 +87,10 @@ func (r *pipelineResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Computed:            true,
 			},
 			"config_source_provider": schema.StringAttribute{
-				MarkdownDescription: "The VCS provider for the pipeline's configuration source. Must be `github_app`.",
+				MarkdownDescription: "The VCS provider for the pipeline's configuration source. Must be one of `github_app` or `github_server`.",
 				Required:            true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("github_app"),
+					stringvalidator.OneOf("github_app", "github_server"),
 				},
 			},
 			"config_source_file_path": schema.StringAttribute{
@@ -106,10 +106,10 @@ func (r *pipelineResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Required:            true,
 			},
 			"checkout_source_provider": schema.StringAttribute{
-				MarkdownDescription: "The VCS provider for the pipeline's checkout source. Must be `github_app`.",
+				MarkdownDescription: "The VCS provider for the pipeline's checkout source. Must be one of `github_app` or `github_server`.",
 				Required:            true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("github_app"),
+					stringvalidator.OneOf("github_app", "github_server"),
 				},
 			},
 			"checkout_source_repo_full_name": schema.StringAttribute{

--- a/internal/provider/pipeline_resource_test.go
+++ b/internal/provider/pipeline_resource_test.go
@@ -109,6 +109,93 @@ func TestAccPipelineResource(t *testing.T) {
 	})
 }
 
+func TestAccPipelineResourceGithubServer(t *testing.T) {
+	uuidRegex, err := regexp.Compile(`[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}`)
+	if err != nil {
+		t.Fatalf("Regex to check UUID could not be created")
+	}
+	dateRegex, err := regexp.Compile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$`)
+	if err != nil {
+		t.Fatal("Could not create Date Regex for testing.")
+	}
+	pipelineName := rand.Text()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccPipelineResourceGithubServerConfig("20209578-aa1c-4b4c-9ca5-f6e38a47cf73", pipelineName, "original description"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_pipeline.test_pipeline_github_server",
+						tfjsonpath.New("project_id"),
+						knownvalue.StringExact("20209578-aa1c-4b4c-9ca5-f6e38a47cf73"),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_pipeline.test_pipeline_github_server",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(pipelineName),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_pipeline.test_pipeline_github_server",
+						tfjsonpath.New("id"),
+						knownvalue.StringRegexp(uuidRegex),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_pipeline.test_pipeline_github_server",
+						tfjsonpath.New("created_at"),
+						knownvalue.StringRegexp(dateRegex),
+					),
+				},
+			},
+			{
+				Config: testAccPipelineResourceGithubServerConfig("20209578-aa1c-4b4c-9ca5-f6e38a47cf73", pipelineName, "updated description"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_pipeline.test_pipeline_github_server",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact("updated description"),
+					),
+				},
+			},
+			// ImportState testing
+			{
+				ResourceName:      "circleci_pipeline.test_pipeline_github_server",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					pipelineId, found := s.RootModule().Resources["circleci_pipeline.test_pipeline_github_server"].Primary.Attributes["id"]
+					if !found {
+						return "", errors.New("attribute circleci_pipeline.test_pipeline_github_server.id not found")
+					}
+					projectId, found := s.RootModule().Resources["circleci_pipeline.test_pipeline_github_server"].Primary.Attributes["project_id"]
+					if !found {
+						return "", errors.New("attribute circleci_pipeline.test_pipeline_github_server.project_id not found")
+					}
+					return fmt.Sprintf("%s/%s", projectId, pipelineId), nil
+				},
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccPipelineResourceGithubServerConfig(project_id, name, description string) string {
+	return fmt.Sprintf(`
+resource "circleci_pipeline" "test_pipeline_github_server" {
+	project_id = %[1]q
+	name = %[2]q
+	description = %[3]q
+	config_source_provider = "github_server"
+	config_source_file_path = "config_source_file_path"
+	config_source_repo_external_id = "2259"
+	checkout_source_provider = "github_server"
+	checkout_source_repo_external_id = "2259"
+}
+`, project_id, name, description)
+}
+
 func testAccPipelineResourceConfig(project_id, name, description string) string {
 	return fmt.Sprintf(`
 resource "circleci_pipeline" "test_pipeline" {

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -91,12 +91,12 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"checkout_ref": schema.StringAttribute{
-				MarkdownDescription: "checkout_ref of the circleci trigger",
-				Required:            true,
+				MarkdownDescription: "The ref to use when checking out code for pipeline runs created from this trigger. Always required when `event_source_provider` is `webhook` or `schedule`. When `event_source_provider` is `github_app` or `github_server`, only expected if the event source repository differs from the checkout source repository of the associated pipeline definition. Otherwise, must be omitted.",
+				Optional:            true,
 			},
 			"config_ref": schema.StringAttribute{
-				MarkdownDescription: "config_ref of the circleci trigger",
-				Required:            true,
+				MarkdownDescription: "The ref to use when fetching configuration for pipeline runs created from this trigger. Always required when `event_source_provider` is `webhook` or `schedule`. When `event_source_provider` is `github_app` or `github_server`, only expected if the event source repository differs from the config source repository of the associated pipeline definition. Otherwise, must be omitted.",
+				Optional:            true,
 			},
 			"event_source_provider": schema.StringAttribute{
 				MarkdownDescription: "event_source_provider of the circleci trigger",

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -152,18 +152,18 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	switch circleCiTerrformTriggerResource.EventSourceProvider.ValueString() {
-	case "github_app":
+	case "github_app", "github_server":
 		if !isValidEventPreset(circleCiTerrformTriggerResource.EventPreset.ValueString()) {
 			resp.Diagnostics.AddError(
 				"Error creating CircleCI trigger",
-				"CircleCI trigger with github_app provider has an unexpected event_preset",
+				"CircleCI trigger with "+circleCiTerrformTriggerResource.EventSourceProvider.ValueString()+" provider has an unexpected event_preset",
 			)
 			return
 		}
 		if !circleCiTerrformTriggerResource.EventName.IsNull() {
 			resp.Diagnostics.AddError(
 				"Error creating CircleCI trigger",
-				"CircleCI trigger with github_app provider does not support event_name",
+				"CircleCI trigger with "+circleCiTerrformTriggerResource.EventSourceProvider.ValueString()+" provider does not support event_name",
 			)
 			return
 		}
@@ -192,7 +192,7 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 	default:
 		resp.Diagnostics.AddError(
 			"Error creating CircleCI trigger",
-			"CircleCI trigger has an unexpected event source provider: should be either github_app or webhook",
+			"CircleCI trigger has an unexpected event source provider: should be either github_app, github_server, or webhook",
 		)
 		return
 	}
@@ -339,7 +339,7 @@ func (r *triggerResource) Read(ctx context.Context, req resource.ReadRequest, re
 	switch triggerState.EventSourceProvider.ValueString() {
 	case "webhook":
 		triggerState.EventSourceWebHookSender = types.StringValue(readTrigger.EventSource.Webhook.Sender)
-	case "github_app":
+	case "github_app", "github_server":
 	}
 
 	if readTrigger.EventName == "" {

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -245,8 +245,12 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 	// Map response body to schema and populate Computed attribute values
 	circleCiTerrformTriggerResource.Id = types.StringValue(newReturnedTrigger.ID)
 	circleCiTerrformTriggerResource.PipelineId = types.StringValue(circleCiTerrformTriggerResource.PipelineId.ValueString())
-	circleCiTerrformTriggerResource.CheckoutRef = types.StringValue(newReturnedTrigger.CheckoutRef)
-	circleCiTerrformTriggerResource.ConfigRef = types.StringValue(newReturnedTrigger.ConfigRef)
+	if newReturnedTrigger.CheckoutRef != "" {
+		circleCiTerrformTriggerResource.CheckoutRef = types.StringValue(newReturnedTrigger.CheckoutRef)
+	}
+	if newReturnedTrigger.ConfigRef != "" {
+		circleCiTerrformTriggerResource.ConfigRef = types.StringValue(newReturnedTrigger.ConfigRef)
+	}
 	circleCiTerrformTriggerResource.EventSourceProvider = types.StringValue(newReturnedTrigger.EventSource.Provider)
 	circleCiTerrformTriggerResource.EventSourceRepoFullName = types.StringValue(newReturnedTrigger.EventSource.Repo.FullName)
 

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -110,17 +110,17 @@ func TestAccTriggerResourceGithubServer(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccTriggerResourceGithubServerConfig("61169e84-93ee-415d-8d65-ddf6dc0d2939", "fefb451c-9966-4b75-b555-d4d94d7116ef"),
+				Config: testAccTriggerResourceGithubServerConfig("20209578-aa1c-4b4c-9ca5-f6e38a47cf73", "9c7c4e85-5022-41d0-a6b0-705cfa856485"),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"circleci_trigger.test_trigger_github_server",
 						tfjsonpath.New("project_id"),
-						knownvalue.StringExact("61169e84-93ee-415d-8d65-ddf6dc0d2939"),
+						knownvalue.StringExact("20209578-aa1c-4b4c-9ca5-f6e38a47cf73"),
 					),
 					statecheck.ExpectKnownValue(
 						"circleci_trigger.test_trigger_github_server",
 						tfjsonpath.New("pipeline_id"),
-						knownvalue.StringExact("fefb451c-9966-4b75-b555-d4d94d7116ef"),
+						knownvalue.StringExact("9c7c4e85-5022-41d0-a6b0-705cfa856485"),
 					),
 				},
 			},
@@ -152,7 +152,7 @@ resource "circleci_trigger" "test_trigger_github_server" {
   project_id                     = %[1]q
   pipeline_id                    = %[2]q
   event_source_provider          = "github_server"
-  event_source_repo_external_id  = "952038793"
+  event_source_repo_external_id  = "2259"
   event_preset                   = "all-pushes"
   checkout_ref                   = "some checkout ref github server"
   config_ref                     = "some config ref github server"

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -154,8 +154,6 @@ resource "circleci_trigger" "test_trigger_github_server" {
   event_source_provider          = "github_server"
   event_source_repo_external_id  = "2259"
   event_preset                   = "all-pushes"
-  checkout_ref                   = "some checkout ref github server"
-  config_ref                     = "some config ref github server"
   disabled                       = false
 }
 `, project_id, pipeline_id)

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -103,6 +103,64 @@ func TestAccTriggerResourceWebhook(t *testing.T) {
 	})
 }
 
+func TestAccTriggerResourceGithubServer(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccTriggerResourceGithubServerConfig("61169e84-93ee-415d-8d65-ddf6dc0d2939", "fefb451c-9966-4b75-b555-d4d94d7116ef"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_trigger.test_trigger_github_server",
+						tfjsonpath.New("project_id"),
+						knownvalue.StringExact("61169e84-93ee-415d-8d65-ddf6dc0d2939"),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_trigger.test_trigger_github_server",
+						tfjsonpath.New("pipeline_id"),
+						knownvalue.StringExact("fefb451c-9966-4b75-b555-d4d94d7116ef"),
+					),
+				},
+			},
+			// ImportState testing
+			{
+				ResourceName:            "circleci_trigger.test_trigger_github_server",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"pipeline_id"},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					triggerId, found := s.RootModule().Resources["circleci_trigger.test_trigger_github_server"].Primary.Attributes["id"]
+					if !found {
+						return "", errors.New("attribute circleci_trigger.test_trigger_github_server.id not found")
+					}
+					projectId, found := s.RootModule().Resources["circleci_trigger.test_trigger_github_server"].Primary.Attributes["project_id"]
+					if !found {
+						return "", errors.New("attribute circleci_trigger.test_trigger_github_server.project_id not found")
+					}
+					return fmt.Sprintf("%s/%s", projectId, triggerId), nil
+				},
+			},
+		},
+	})
+}
+
+func testAccTriggerResourceGithubServerConfig(project_id, pipeline_id string) string {
+	return fmt.Sprintf(`
+resource "circleci_trigger" "test_trigger_github_server" {
+  project_id                     = %[1]q
+  pipeline_id                    = %[2]q
+  event_source_provider          = "github_server"
+  event_source_repo_external_id  = "952038793"
+  event_preset                   = "all-pushes"
+  checkout_ref                   = "some checkout ref github server"
+  config_ref                     = "some config ref github server"
+  disabled                       = false
+}
+`, project_id, pipeline_id)
+}
+
 func testAccTriggerResourceGithubAppConfig(project_id, pipeline_id string) string {
 	return fmt.Sprintf(`
 resource "circleci_trigger" "test_trigger_github" {


### PR DESCRIPTION
## Summary

- **`circleci_pipeline`**: accept `github_server` as a valid value for `config_source_provider` and `checkout_source_provider` (previously `github_app` only)
- **`circleci_trigger`**: accept `github_server` as a valid value for `event_source_provider`, with the same validation rules as `github_app` (valid `event_preset` required; `event_name` not supported)
- Add acceptance test `TestAccTriggerResourceGithubServer` mirroring the existing `github_app` test
- Add `examples/resources/circleci_trigger/github_server.tf` example

Closes [SC-3101](https://circleci.atlassian.net/browse/SC-3101)

## Decision note: cross-provider validation

The ticket states that `github_server` and `github_app` are distinct labels and a trigger must not be attached to a pipeline of the other type. This constraint is **not enforced at the Terraform provider level** — it is delegated to the CircleCI API, which will return an error at apply time if the combination is invalid. Provider-level cross-validation (fetching the pipeline's provider on every plan) was considered but deferred to keep this change minimal. A follow-up ticket can add it if API error messages prove insufficient.

## Test plan

- [ ] `TF_ACC=1 CIRCLE_TOKEN=<token> go test ./internal/provider/... -run TestAccTriggerResourceGithubServer -v` against a `github_server`-backed project
- [ ] Existing acceptance tests (`TestAccTriggerResourceGithub`, `TestAccTriggerResourceWebhook`) continue to pass
- [ ] `circleci_pipeline` resource with `config_source_provider = "github_server"` applies without schema validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SC-3101]: https://circleci.atlassian.net/browse/SC-3101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ