### PR TITLE
feat: add schedule trigger support to circleci_trigger resource [sc-2438]

### DIFF
--- a/examples/resources/circleci_trigger/schedule.tf
+++ b/examples/resources/circleci_trigger/schedule.tf
@@ -1,0 +1,15 @@
+# Schedule trigger — runs the pipeline every day at 01:00 UTC
+resource "circleci_trigger" "nightly" {
+  project_id            = "61169e84-93ee-415d-8d65-ddf6dc0d2939"
+  pipeline_id           = "fefb451c-9966-4b75-b555-d4d94d7116ef"
+  event_source_provider = "schedule"
+  event_name            = "Nightly build"
+  cron_expression       = "0 1 * * *"
+  checkout_ref          = "main"
+  config_ref            = "main"
+  attribution_actor     = "current"
+
+  parameters = {
+    deploy_env = "staging"
+  }
+}

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/CircleCI-Public/circleci-sdk-go/common"
 	"github.com/CircleCI-Public/circleci-sdk-go/trigger"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -42,6 +43,9 @@ type triggerResourceModel struct {
 	EventPreset               types.String `tfsdk:"event_preset"`
 	EventName                 types.String `tfsdk:"event_name"`
 	Disabled                  types.Bool   `tfsdk:"disabled"`
+	CronExpression            types.String `tfsdk:"cron_expression"`
+	AttributionActor          types.String `tfsdk:"attribution_actor"`
+	Parameters                types.Map    `tfsdk:"parameters"`
 }
 
 // NewTriggerResource is a helper function to simplify the provider implementation.
@@ -137,6 +141,19 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
 			},
+			"cron_expression": schema.StringAttribute{
+				MarkdownDescription: "A cron expression defining when the trigger fires (e.g. `*/5 * * * *` for every 5 minutes). Required when `event_source_provider` is `schedule`.",
+				Optional:            true,
+			},
+			"attribution_actor": schema.StringAttribute{
+				MarkdownDescription: "The actor to attribute pipeline runs to. One of `current` or `system`. Only applicable when `event_source_provider` is `schedule`. If omitted the API defaults to `current`. Note: not returned by the read API — external changes will not be detected.",
+				Optional:            true,
+			},
+			"parameters": schema.MapAttribute{
+				MarkdownDescription: "Pipeline parameters to pass to triggered pipeline runs. Values must be strings. Only applicable when `event_source_provider` is `schedule`.",
+				ElementType:         types.StringType,
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -189,10 +206,25 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 			)
 			return
 		}
+	case "schedule":
+		if circleCiTerrformTriggerResource.CronExpression.IsNull() {
+			resp.Diagnostics.AddError(
+				"Error creating CircleCI trigger",
+				"CircleCI trigger with schedule provider requires a cron_expression",
+			)
+			return
+		}
+		if circleCiTerrformTriggerResource.EventName.IsNull() {
+			resp.Diagnostics.AddError(
+				"Error creating CircleCI trigger",
+				"CircleCI trigger with schedule provider requires an event_name",
+			)
+			return
+		}
 	default:
 		resp.Diagnostics.AddError(
 			"Error creating CircleCI trigger",
-			"CircleCI trigger has an unexpected event source provider: should be either github_app or webhook",
+			"CircleCI trigger has an unexpected event source provider: expected one of github_app, webhook, or schedule",
 		)
 		return
 	}
@@ -215,6 +247,12 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 		Repo:     newRepo,
 		Webhook:  newWebHook,
 	}
+	if circleCiTerrformTriggerResource.EventSourceProvider.ValueString() == "schedule" {
+		newEventSource.Schedule = common.Schedule{
+			CronExpression:   circleCiTerrformTriggerResource.CronExpression.ValueString(),
+			AttributionActor: circleCiTerrformTriggerResource.AttributionActor.ValueString(),
+		}
+	}
 
 	// New Trigger
 	disabled := circleCiTerrformTriggerResource.Disabled.ValueBool()
@@ -225,6 +263,18 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 		EventSource: newEventSource,
 		EventPreset: circleCiTerrformTriggerResource.EventPreset.ValueString(),
 		Disabled:    &disabled,
+	}
+	if !circleCiTerrformTriggerResource.Parameters.IsNull() && !circleCiTerrformTriggerResource.Parameters.IsUnknown() {
+		params := make(map[string]string)
+		resp.Diagnostics.Append(circleCiTerrformTriggerResource.Parameters.ElementsAs(ctx, &params, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		paramsAny := make(map[string]any, len(params))
+		for k, v := range params {
+			paramsAny[k] = v
+		}
+		newTrigger.Parameters = paramsAny
 	}
 
 	// Create new Trigger
@@ -270,6 +320,11 @@ func (r *triggerResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 	circleCiTerrformTriggerResource.CreatedAt = types.StringValue(readTrigger.CreatedAt)
 	circleCiTerrformTriggerResource.EventSourceRepoFullName = types.StringValue(readTrigger.EventSource.Repo.FullName)
+	if readTrigger.EventSource.Schedule.CronExpression != "" {
+		circleCiTerrformTriggerResource.CronExpression = types.StringValue(readTrigger.EventSource.Schedule.CronExpression)
+	}
+	// attribution_actor is not in the API response — plan value already set
+	circleCiTerrformTriggerResource.Parameters = triggerParametersFromAny(readTrigger.Parameters)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, circleCiTerrformTriggerResource)
@@ -340,6 +395,14 @@ func (r *triggerResource) Read(ctx context.Context, req resource.ReadRequest, re
 	case "webhook":
 		triggerState.EventSourceWebHookSender = types.StringValue(readTrigger.EventSource.Webhook.Sender)
 	case "github_app":
+	case "schedule":
+		if readTrigger.EventSource.Schedule.CronExpression != "" {
+			triggerState.CronExpression = types.StringValue(readTrigger.EventSource.Schedule.CronExpression)
+		} else {
+			triggerState.CronExpression = types.StringNull()
+		}
+		// attribution_actor is not in the API read response — preserve existing state value
+		triggerState.Parameters = triggerParametersFromAny(readTrigger.Parameters)
 	}
 
 	if readTrigger.EventName == "" {
@@ -408,6 +471,12 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 		Repo:     newRepo,
 		Webhook:  newWebHook,
 	}
+	if state.EventSourceProvider.ValueString() == "schedule" {
+		newEventSource.Schedule = common.Schedule{
+			CronExpression:   state.CronExpression.ValueString(),
+			AttributionActor: state.AttributionActor.ValueString(),
+		}
+	}
 
 	// New Trigger
 	disabled := state.Disabled.ValueBool()
@@ -418,6 +487,18 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 		EventSource: newEventSource,
 		EventPreset: state.EventPreset.ValueString(),
 		Disabled:    &disabled,
+	}
+	if !state.Parameters.IsNull() && !state.Parameters.IsUnknown() {
+		params := make(map[string]string)
+		resp.Diagnostics.Append(state.Parameters.ElementsAs(ctx, &params, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		paramsAny := make(map[string]any, len(params))
+		for k, v := range params {
+			paramsAny[k] = v
+		}
+		updates.Parameters = paramsAny
 	}
 
 	// update the triger
@@ -448,6 +529,11 @@ func (r *triggerResource) Update(ctx context.Context, req resource.UpdateRequest
 	state.EventPreset = types.StringValue(updatedTrigger.EventPreset)
 	state.EventName = types.StringValue(updatedTrigger.EventName)
 	state.CreatedAt = types.StringValue(updatedTrigger.CreatedAt)
+	if updatedTrigger.EventSource.Schedule.CronExpression != "" {
+		state.CronExpression = types.StringValue(updatedTrigger.EventSource.Schedule.CronExpression)
+	}
+	// attribution_actor not in response — plan value already in state
+	state.Parameters = triggerParametersFromAny(updatedTrigger.Parameters)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -530,6 +616,21 @@ func isValidEventPreset(eventPreset string) bool {
 	default:
 		return false
 	}
+}
+
+// triggerParametersFromAny converts an API map[string]any to a Terraform types.Map.
+// Returns a null map when params is empty so that unset parameters in config
+// don't drift against an empty API response.
+func triggerParametersFromAny(params map[string]any) types.Map {
+	if len(params) == 0 {
+		return types.MapNull(types.StringType)
+	}
+	elements := make(map[string]attr.Value, len(params))
+	for k, v := range params {
+		elements[k] = types.StringValue(fmt.Sprintf("%v", v))
+	}
+	result, _ := types.MapValue(types.StringType, elements)
+	return result
 }
 
 func isApiNotFoundError(err error) bool {

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -132,3 +132,91 @@ resource "circleci_trigger" "test_trigger_webhook" {
 }
 `, event_name, project_id, pipeline_id)
 }
+
+func TestAccTriggerResourceSchedule(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read
+			{
+				Config: testAccTriggerResourceScheduleConfig(
+					"61169e84-93ee-415d-8d65-ddf6dc0d2939",
+					"FILL_IN_PIPELINE_DEFINITION_ID_THAT_SUPPORTS_SCHEDULE_TRIGGERS",
+					"Nightly build",
+					"0 1 * * *",
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_trigger.test_trigger_schedule",
+						tfjsonpath.New("event_source_provider"),
+						knownvalue.StringExact("schedule"),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_trigger.test_trigger_schedule",
+						tfjsonpath.New("event_name"),
+						knownvalue.StringExact("Nightly build"),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_trigger.test_trigger_schedule",
+						tfjsonpath.New("cron_expression"),
+						knownvalue.StringExact("0 1 * * *"),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_trigger.test_trigger_schedule",
+						tfjsonpath.New("disabled"),
+						knownvalue.Bool(false),
+					),
+				},
+			},
+			// Update — change cron expression
+			{
+				Config: testAccTriggerResourceScheduleConfig(
+					"61169e84-93ee-415d-8d65-ddf6dc0d2939",
+					"FILL_IN_PIPELINE_DEFINITION_ID_THAT_SUPPORTS_SCHEDULE_TRIGGERS",
+					"Nightly build",
+					"0 2 * * *",
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_trigger.test_trigger_schedule",
+						tfjsonpath.New("cron_expression"),
+						knownvalue.StringExact("0 2 * * *"),
+					),
+				},
+			},
+			// ImportState
+			{
+				ResourceName:            "circleci_trigger.test_trigger_schedule",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"pipeline_id", "attribution_actor"},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					triggerID, found := s.RootModule().Resources["circleci_trigger.test_trigger_schedule"].Primary.Attributes["id"]
+					if !found {
+						return "", errors.New("attribute id not found")
+					}
+					projectID, found := s.RootModule().Resources["circleci_trigger.test_trigger_schedule"].Primary.Attributes["project_id"]
+					if !found {
+						return "", errors.New("attribute project_id not found")
+					}
+					return fmt.Sprintf("%s/%s", projectID, triggerID), nil
+				},
+			},
+		},
+	})
+}
+
+func testAccTriggerResourceScheduleConfig(projectID, pipelineID, eventName, cron string) string {
+	return fmt.Sprintf(`
+resource "circleci_trigger" "test_trigger_schedule" {
+  project_id            = %[1]q
+  pipeline_id           = %[2]q
+  event_source_provider = "schedule"
+  event_name            = %[3]q
+  cron_expression       = %[4]q
+  checkout_ref          = "main"
+  config_ref            = "main"
+}
+`, projectID, pipelineID, eventName, cron)
+}


### PR DESCRIPTION
## Summary

Extends the existing `circleci_trigger` resource to support `event_source_provider = "schedule"`, enabling cron-based pipeline triggers via Terraform.

**Depends on:** CircleCI-Public/circleci-sdk-go#41 (SDK types for schedule triggers)

**Changes:**
- `trigger_resource.go`: three new optional attributes (`cron_expression`, `attribution_actor`, `parameters`); new `"schedule"` validation branch in Create; schedule fields wired into Read and Update
- `trigger_resource_test.go`: `TestAccTriggerResourceSchedule` acceptance test (pipeline definition ID placeholder needs to be filled in before running)
- `examples/resources/circleci_trigger/schedule.tf`: usage example

> **Note:** This PR is a draft opened as a starting point. Feel free to discard and reimplement from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)