### PR TITLE
feat: add import support for context environment variable resource

### DIFF
--- a/docs/resources/context_environment_variable.md
+++ b/docs/resources/context_environment_variable.md
@@ -19,9 +19,25 @@ description: |-
 
 - `context_id` (String) context id of the circleci context environment variable
 - `name` (String) name of the circleci context environment variable
-- `value` (String) value of the circleci context environment variable
+- `value` (String, Sensitive) value of the circleci context environment variable
 
 ### Read-Only
 
 - `created_at` (String) created date of the circleci context environment variable
 - `updated_at` (String) updated date of the circleci context environment variable
+
+## Import
+
+Import is supported using `context_id/env_var_name`:
+
+```shell
+terraform import circleci_context_environment_variable.example "<context_id>/<env_var_name>"
+```
+
+CircleCI does not expose context environment variable values via API. You must provide `value` in Terraform configuration before or after import so Terraform can manage the resource.
+
+> **Note:** Because CircleCI does not return the secret value, the first `terraform apply`
+> after import will detect a difference in `value` (null to your configured value) and
+> **replace** (destroy + recreate) the environment variable. Since the PUT API is an upsert,
+> this writes the same value back. To minimize disruption, import all variables first,
+> then run a single `terraform apply` to reconcile them all at once.

--- a/docs/resources/context_environment_variable.md
+++ b/docs/resources/context_environment_variable.md
@@ -38,6 +38,5 @@ CircleCI does not expose context environment variable values via API. You must p
 
 > **Note:** Because CircleCI does not return the secret value, the first `terraform apply`
 > after import will detect a difference in `value` (null to your configured value) and
-> **replace** (destroy + recreate) the environment variable. Since the PUT API is an upsert,
-> this writes the same value back. To minimize disruption, import all variables first,
-> then run a single `terraform apply` to reconcile them all at once.
+> perform an **in-place update**. Since the API is an upsert, this safely writes the
+> same value back without deleting the variable.

--- a/docs/resources/context_environment_variable.md
+++ b/docs/resources/context_environment_variable.md
@@ -38,5 +38,6 @@ CircleCI does not expose context environment variable values via API. You must p
 
 > **Note:** Because CircleCI does not return the secret value, the first `terraform apply`
 > after import will detect a difference in `value` (null to your configured value) and
-> perform an **in-place update**. Since the API is an upsert, this safely writes the
-> same value back without deleting the variable.
+> **replace** (destroy + recreate) the environment variable. Since the PUT API is an upsert,
+> this writes the same value back. To minimize disruption, import all variables first,
+> then run a single `terraform apply` to reconcile them all at once.

--- a/internal/provider/context_environment_variable_resource.go
+++ b/internal/provider/context_environment_variable_resource.go
@@ -12,8 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -60,9 +58,6 @@ func (r *contextEnvironmentVariableResource) Schema(_ context.Context, _ resourc
 				MarkdownDescription: "value of the circleci context environment variable",
 				Required:            true,
 				Sensitive:           true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"updated_at": schema.StringAttribute{
 				MarkdownDescription: "updated date of the circleci context environment variable",

--- a/internal/provider/context_environment_variable_resource.go
+++ b/internal/provider/context_environment_variable_resource.go
@@ -6,8 +6,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/CircleCI-Public/circleci-sdk-go/envcontext"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -17,8 +19,9 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource              = &contextEnvironmentVariableResource{}
-	_ resource.ResourceWithConfigure = &contextEnvironmentVariableResource{}
+	_ resource.Resource                = &contextEnvironmentVariableResource{}
+	_ resource.ResourceWithConfigure   = &contextEnvironmentVariableResource{}
+	_ resource.ResourceWithImportState = &contextEnvironmentVariableResource{}
 )
 
 // contextEnvironmentVariableResourceModel maps the output schema.
@@ -56,8 +59,8 @@ func (r *contextEnvironmentVariableResource) Schema(_ context.Context, _ resourc
 			"value": schema.StringAttribute{
 				MarkdownDescription: "value of the circleci context environment variable",
 				Required:            true,
+				Sensitive:           true,
 				PlanModifiers: []planmodifier.String{
-					// *** This tells Terraform to replace if 'context_id' changes ***
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
@@ -134,14 +137,6 @@ func (r *contextEnvironmentVariableResource) Read(ctx context.Context, req resou
 		return
 	}
 
-	if contextEnvironmentVariableState.Value.IsNull() {
-		resp.Diagnostics.AddError(
-			"Missing environment variable value",
-			"Missing environment variable value",
-		)
-		return
-	}
-
 	contextEnvironmentVariables, err := r.client.List(ctx, contextEnvironmentVariableState.ContextId.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -151,15 +146,21 @@ func (r *contextEnvironmentVariableResource) Read(ctx context.Context, req resou
 		return
 	}
 
-	// Fill restrictions
+	var found bool
 	for _, elem := range contextEnvironmentVariables {
 		if elem.Variable == contextEnvironmentVariableState.Name.ValueString() {
 			contextEnvironmentVariableState.Name = types.StringValue(elem.Variable)
 			contextEnvironmentVariableState.UpdatedAt = types.StringValue(elem.UpdatedAt.Format("2006-01-02T15:04:05.000Z"))
 			contextEnvironmentVariableState.CreatedAt = types.StringValue(elem.CreatedAt.Format("2006-01-02T15:04:05.000Z"))
 			contextEnvironmentVariableState.ContextId = types.StringValue(elem.ContextId)
+			found = true
 			break
 		}
+	}
+
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	// Set state
@@ -170,8 +171,18 @@ func (r *contextEnvironmentVariableResource) Read(ctx context.Context, req resou
 	}
 }
 
-// Update updates the resource and sets the updated Terraform state on success.
+// Update persists plan values (such as value) into state.
+// The context env var API uses PUT (upsert) via Create, so no separate update call is needed.
 func (r *contextEnvironmentVariableResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan contextEnvironmentVariableResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = resp.State.Set(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
@@ -214,4 +225,24 @@ func (r *contextEnvironmentVariableResource) Configure(_ context.Context, req re
 	}
 
 	r.client = client.EnvironmentVariableService
+}
+
+// ImportState imports an existing resource into Terraform state.
+// Expected import ID format: "context_id/env_var_name".
+func (r *contextEnvironmentVariableResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.SplitN(req.ID, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID Format",
+			fmt.Sprintf("Expected import ID format: 'context_id/env_var_name'. Got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("context_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), parts[1])...)
+	resp.Diagnostics.AddWarning(
+		"Context environment variable value cannot be read from API",
+		"CircleCI does not expose context environment variable values. Ensure the resource 'value' is defined in your Terraform configuration.",
+	)
 }

--- a/internal/provider/context_environment_variable_resource.go
+++ b/internal/provider/context_environment_variable_resource.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -53,11 +55,17 @@ func (r *contextEnvironmentVariableResource) Schema(_ context.Context, _ resourc
 			"name": schema.StringAttribute{
 				MarkdownDescription: "name of the circleci context environment variable",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"value": schema.StringAttribute{
 				MarkdownDescription: "value of the circleci context environment variable",
 				Required:            true,
 				Sensitive:           true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				MarkdownDescription: "updated date of the circleci context environment variable",
@@ -66,6 +74,9 @@ func (r *contextEnvironmentVariableResource) Schema(_ context.Context, _ resourc
 			"context_id": schema.StringAttribute{
 				MarkdownDescription: "context id of the circleci context environment variable",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"created_at": schema.StringAttribute{
 				MarkdownDescription: "created date of the circleci context environment variable",
@@ -166,18 +177,8 @@ func (r *contextEnvironmentVariableResource) Read(ctx context.Context, req resou
 	}
 }
 
-// Update persists plan values (such as value) into state.
-// The context env var API uses PUT (upsert) via Create, so no separate update call is needed.
+// Update is a no-op: all mutable attributes use RequiresReplace(), so changes run as delete+create.
 func (r *contextEnvironmentVariableResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan contextEnvironmentVariableResourceModel
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	diags = resp.State.Set(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
 }
 
 // Delete deletes the resource and removes the Terraform state on success.

--- a/internal/provider/context_environment_variable_resource_test.go
+++ b/internal/provider/context_environment_variable_resource_test.go
@@ -5,12 +5,14 @@ package provider
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -43,6 +45,46 @@ func TestAccContextEnvironmentVariableResource(t *testing.T) {
 				},
 			},
 			// Update and Read testing
+			{
+				Config: testAccContextEnvironmentVariableResourceConfig("one", "second_value"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_context_environment_variable.test_env",
+						tfjsonpath.New("context_id"),
+						knownvalue.StringExact("e51158a2-f59c-4740-9eb4-d20609baa07e"),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_context_environment_variable.test_env",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact("one"),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_context_environment_variable.test_env",
+						tfjsonpath.New("value"),
+						knownvalue.StringExact("second_value"),
+					),
+				},
+			},
+			// ImportState testing
+			{
+				ResourceName:                         "circleci_context_environment_variable.test_env",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+				ImportStateVerifyIgnore:              []string{"value"},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					contextID, found := s.RootModule().Resources["circleci_context_environment_variable.test_env"].Primary.Attributes["context_id"]
+					if !found {
+						return "", errors.New("attribute circleci_context_environment_variable.test_env.context_id not found")
+					}
+					envName, found := s.RootModule().Resources["circleci_context_environment_variable.test_env"].Primary.Attributes["name"]
+					if !found {
+						return "", errors.New("attribute circleci_context_environment_variable.test_env.name not found")
+					}
+					return fmt.Sprintf("%s/%s", contextID, envName), nil
+				},
+			},
+			// Re-apply config after import to reconcile value in state
 			{
 				Config: testAccContextEnvironmentVariableResourceConfig("one", "second_value"),
 				ConfigStateChecks: []statecheck.StateCheck{


### PR DESCRIPTION
## Summary

Adds `terraform import` support for `circleci_context_environment_variable` using the format `context_id/env_var_name`.

- Implement `ImportState` with `context_id/env_var_name` format and validation
- Add `RequiresReplace` to `name` and `context_id` (previously only on `value`) — changing any identity field now correctly triggers a replace
- Mark `value` as `Sensitive` to prevent secret exposure in plan/state output
- Fix `Read` to remove resource from state when not found (instead of silently keeping stale state)
- Remove null value check in `Read` that blocked the import flow (`Read` never uses `value` — it only fetches metadata from the API)
- Add import warning: CircleCI does not expose secret values, so users must define `value` in config
- Add acceptance tests for import and post-import apply

## Known limitation

Because CircleCI does not return secret values via API, the first `terraform apply` after import will detect a difference in `value` (null → configured value) and **replace** (destroy + recreate) the environment variable. Since the PUT API is an upsert, this writes the same value back. To minimize disruption, import all variables first, then run a single `terraform apply` to reconcile them all at once.

## Test plan

- [x] Acceptance test: import with `context_id/env_var_name` format
- [x] Acceptance test: re-apply config after import reconciles state
- [x] Acceptance test: create, update, and delete lifecycle

```
cat > /Users/vivio/.circleci-cursor/terraform-provider-circleci/.tmp_run_one_test.sh <<'EOF'
#!/usr/bin/env bash
set -euxo pipefail
ARCH=$(uname -m)
case "$ARCH" in
  x86_64) TFARCH=amd64 ;;
  aarch64) TFARCH=arm64 ;;
  *) echo "unsupported arch: $ARCH"; exit 1 ;;
esac
curl -fsSL "https://releases.hashicorp.com/terraform/1.12.2/terraform_1.12.2_linux_${TFARCH}.zip" -o /tmp/tf.zip
sudo unzip -q -o /tmp/tf.zip -d /usr/local/bin
sudo chmod +x /usr/local/bin/terraform
terraform -version

go mod download
go build -v .

go test ./internal/provider/... -count=1 -timeout=30m -race -run '^TestAccContextEnvironmentVariableResource$' -v
EOF
chmod +x /Users/vivio/.circleci-cursor/terraform-provider-circleci/.tmp_run_one_test.sh
bash -ilc 'cd /Users/vivio/.circleci-cursor/terraform-provider-circleci && docker run --rm \
  -v "$PWD:/workspace" \
  -w /workspace \
  -e GOPRIVATE=github.com/CircleCI-Public/circleci-sdk-go \
  -e TF_ACC=1 \
  -e CIRCLE_TOKEN="$CIRCLE_TOKEN" \
  cimg/go:1.26.1 \
  bash /workspace/.tmp_run_one_test.sh' 2>&1 | tail -120
rm -f /Users/vivio/.circleci-cursor/terraform-provider-circleci/.tmp_run_one_test.sh
golang.org/x/text/unicode/norm
golang.org/x/net/internal/httpsfv
google.golang.org/grpc/internal/stats
golang.org/x/text/secure/bidirule
...
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/toproto
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server
github.com/hashicorp/terraform-plugin-framework/providerserver
+ go test ./internal/provider/... -count=1 -timeout=30m -race -run '^TestAccContextEnvironmentVariableResource$' -v
=== RUN   TestAccContextEnvironmentVariableResource
2026/04/28 07:50:20 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524
2026/04/28 07:50:21 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/restrictions?page-token=
2026/04/28 07:50:22 [DEBUG] PUT https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/environment-variable/NIH6XSKTGEAOCHHNRP6JFAHJITY
2026/04/28 07:50:22 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524
2026/04/28 07:50:23 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/restrictions?page-token=
2026/04/28 07:50:23 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524
2026/04/28 07:50:24 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/restrictions?page-token=
2026/04/28 07:50:24 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/environment-variable?page-token=
2026/04/28 07:50:25 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524
2026/04/28 07:50:25 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/restrictions?page-token=
2026/04/28 07:50:26 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/environment-variable?page-token=
2026/04/28 07:50:26 [DEBUG] DELETE https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/environment-variable/NIH6XSKTGEAOCHHNRP6JFAHJITY
2026/04/28 07:50:26 [DEBUG] PUT https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/environment-variable/one
2026/04/28 07:50:27 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524
2026/04/28 07:50:27 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/restrictions?page-token=
2026/04/28 07:50:28 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524
2026/04/28 07:50:28 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/restrictions?page-token=
2026/04/28 07:50:29 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/environment-variable?page-token=
2026/04/28 07:50:29 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524
2026/04/28 07:50:30 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/restrictions?page-token=
2026/04/28 07:50:30 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/environment-variable?page-token=
2026/04/28 07:50:30 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524
2026/04/28 07:50:31 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/restrictions?page-token=
2026/04/28 07:50:31 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/environment-variable?page-token=
2026/04/28 07:50:32 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524
2026/04/28 07:50:32 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/restrictions?page-token=
2026/04/28 07:50:32 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524
2026/04/28 07:50:33 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/restrictions?page-token=
2026/04/28 07:50:33 [DEBUG] GET https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/environment-variable?page-token=
2026/04/28 07:50:34 [DEBUG] DELETE https://circleci.com/api/v2/context/7b9149f8-82f8-4041-a6d1-f647f3371524/environment-variable/one
--- PASS: TestAccContextEnvironmentVariableResource (14.60s)
PASS
ok  	terraform-provider-circleci/internal/provider	15.636s
```

Issue #40