### PR TITLE
Context environment variable import

### DIFF
--- a/docs/resources/context_environment_variable.md
+++ b/docs/resources/context_environment_variable.md
@@ -19,9 +19,25 @@ description: |-
 
 - `context_id` (String) context id of the circleci context environment variable
 - `name` (String) name of the circleci context environment variable
-- `value` (String) value of the circleci context environment variable
+- `value` (String, Sensitive) value of the circleci context environment variable
 
 ### Read-Only
 
 - `created_at` (String) created date of the circleci context environment variable
 - `updated_at` (String) updated date of the circleci context environment variable
+
+## Import
+
+Import is supported using `context_id/env_var_name`:
+
+```shell
+terraform import circleci_context_environment_variable.example "<context_id>/<env_var_name>"
+```
+
+CircleCI does not expose context environment variable values via API. You must provide `value` in Terraform configuration before or after import so Terraform can manage the resource.
+
+> **Note:** Because CircleCI does not return the secret value, the first `terraform apply`
+> after import will detect a difference in `value` (null to your configured value) and
+> **replace** (destroy + recreate) the environment variable. Since the PUT API is an upsert,
+> this writes the same value back. To minimize disruption, import all variables first,
+> then run a single `terraform apply` to reconcile them all at once.

--- a/internal/provider/context_environment_variable_resource.go
+++ b/internal/provider/context_environment_variable_resource.go
@@ -6,8 +6,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/CircleCI-Public/circleci-sdk-go/envcontext"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -17,8 +19,9 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource              = &contextEnvironmentVariableResource{}
-	_ resource.ResourceWithConfigure = &contextEnvironmentVariableResource{}
+	_ resource.Resource                = &contextEnvironmentVariableResource{}
+	_ resource.ResourceWithConfigure   = &contextEnvironmentVariableResource{}
+	_ resource.ResourceWithImportState = &contextEnvironmentVariableResource{}
 )
 
 // contextEnvironmentVariableResourceModel maps the output schema.
@@ -52,12 +55,15 @@ func (r *contextEnvironmentVariableResource) Schema(_ context.Context, _ resourc
 			"name": schema.StringAttribute{
 				MarkdownDescription: "name of the circleci context environment variable",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"value": schema.StringAttribute{
 				MarkdownDescription: "value of the circleci context environment variable",
 				Required:            true,
+				Sensitive:           true,
 				PlanModifiers: []planmodifier.String{
-					// *** This tells Terraform to replace if 'context_id' changes ***
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
@@ -68,6 +74,9 @@ func (r *contextEnvironmentVariableResource) Schema(_ context.Context, _ resourc
 			"context_id": schema.StringAttribute{
 				MarkdownDescription: "context id of the circleci context environment variable",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"created_at": schema.StringAttribute{
 				MarkdownDescription: "created date of the circleci context environment variable",
@@ -134,14 +143,6 @@ func (r *contextEnvironmentVariableResource) Read(ctx context.Context, req resou
 		return
 	}
 
-	if contextEnvironmentVariableState.Value.IsNull() {
-		resp.Diagnostics.AddError(
-			"Missing environment variable value",
-			"Missing environment variable value",
-		)
-		return
-	}
-
 	contextEnvironmentVariables, err := r.client.List(ctx, contextEnvironmentVariableState.ContextId.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -151,15 +152,21 @@ func (r *contextEnvironmentVariableResource) Read(ctx context.Context, req resou
 		return
 	}
 
-	// Fill restrictions
+	var found bool
 	for _, elem := range contextEnvironmentVariables {
 		if elem.Variable == contextEnvironmentVariableState.Name.ValueString() {
 			contextEnvironmentVariableState.Name = types.StringValue(elem.Variable)
 			contextEnvironmentVariableState.UpdatedAt = types.StringValue(elem.UpdatedAt.Format("2006-01-02T15:04:05.000Z"))
 			contextEnvironmentVariableState.CreatedAt = types.StringValue(elem.CreatedAt.Format("2006-01-02T15:04:05.000Z"))
 			contextEnvironmentVariableState.ContextId = types.StringValue(elem.ContextId)
+			found = true
 			break
 		}
+	}
+
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	// Set state
@@ -170,7 +177,7 @@ func (r *contextEnvironmentVariableResource) Read(ctx context.Context, req resou
 	}
 }
 
-// Update updates the resource and sets the updated Terraform state on success.
+// Update is a no-op: all mutable attributes use RequiresReplace(), so changes run as delete+create.
 func (r *contextEnvironmentVariableResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 }
 
@@ -214,4 +221,24 @@ func (r *contextEnvironmentVariableResource) Configure(_ context.Context, req re
 	}
 
 	r.client = client.EnvironmentVariableService
+}
+
+// ImportState imports an existing resource into Terraform state.
+// Expected import ID format: "context_id/env_var_name".
+func (r *contextEnvironmentVariableResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.SplitN(req.ID, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID Format",
+			fmt.Sprintf("Expected import ID format: 'context_id/env_var_name'. Got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("context_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), parts[1])...)
+	resp.Diagnostics.AddWarning(
+		"Context environment variable value cannot be read from API",
+		"CircleCI does not expose context environment variable values. Ensure the resource 'value' is defined in your Terraform configuration.",
+	)
 }

--- a/internal/provider/context_environment_variable_resource_test.go
+++ b/internal/provider/context_environment_variable_resource_test.go
@@ -5,12 +5,14 @@ package provider
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
@@ -43,6 +45,46 @@ func TestAccContextEnvironmentVariableResource(t *testing.T) {
 				},
 			},
 			// Update and Read testing
+			{
+				Config: testAccContextEnvironmentVariableResourceConfig("one", "second_value"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_context_environment_variable.test_env",
+						tfjsonpath.New("context_id"),
+						knownvalue.StringExact("e51158a2-f59c-4740-9eb4-d20609baa07e"),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_context_environment_variable.test_env",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact("one"),
+					),
+					statecheck.ExpectKnownValue(
+						"circleci_context_environment_variable.test_env",
+						tfjsonpath.New("value"),
+						knownvalue.StringExact("second_value"),
+					),
+				},
+			},
+			// ImportState testing
+			{
+				ResourceName:                         "circleci_context_environment_variable.test_env",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+				ImportStateVerifyIgnore:              []string{"value"},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					contextID, found := s.RootModule().Resources["circleci_context_environment_variable.test_env"].Primary.Attributes["context_id"]
+					if !found {
+						return "", errors.New("attribute circleci_context_environment_variable.test_env.context_id not found")
+					}
+					envName, found := s.RootModule().Resources["circleci_context_environment_variable.test_env"].Primary.Attributes["name"]
+					if !found {
+						return "", errors.New("attribute circleci_context_environment_variable.test_env.name not found")
+					}
+					return fmt.Sprintf("%s/%s", contextID, envName), nil
+				},
+			},
+			// Re-apply config after import to reconcile value in state
 			{
 				Config: testAccContextEnvironmentVariableResourceConfig("one", "second_value"),
 				ConfigStateChecks: []statecheck.StateCheck{


### PR DESCRIPTION
This PR implements the `ImportState` interface for the `circleci_context_environment_variable` resource, allowing users to bring existing environment variables under Terraform management. It also enhances security by marking the `value` attribute as sensitive and clarifies resource behavior during updates.

## Changes

### 🚀 Features
* **Import Support**: Added `ImportState` functionality using the format `context_id/env_var_name`.
* **Sensitive Values**: Marked the `value` attribute as `Sensitive: true` to ensure secrets are masked in Terraform console output.

### 🛠️ Improvements & Bug Fixes
* **Drift Detection**: Updated the `Read` method to properly call `resp.State.RemoveResource(ctx)` if a variable is deleted outside of Terraform, preventing "ghost" resources in state.
* **Schema Enforcement**: Added `RequiresReplace()` to `name`, `value`, and `context_id`. Since the CircleCI API treats these updates as an upsert (replacement of the secret), this alignment ensures Terraform plan accuracy.
* **Code Cleanup**: Removed an unnecessary manual check for null values in `Read` that interfered with the standard import lifecycle.
* **Documentation**: Added an "Import" section to the resource documentation explaining the ID format and the security-related "replace" behavior on the first apply post-import.

### 🧪 Testing
* Added an acceptance test case covering the full import lifecycle:
    1.  Creating a resource.
    2.  Importing it via the new ID format.
    3.  Verifying state consistency (ignoring the secret value which CircleCI doesn't return).
    4.  Re-applying configuration to ensure the `value` is reconciled correctly.

## Important Note for Users
CircleCI's API does not return the plaintext value of environment variables. Consequently, the first `terraform apply` after an import will show a "replace" action. This is expected behavior as Terraform must write the locally configured value back to CircleCI to ensure the state is fully synchronized.