### PR TITLE
Fix `runner_host` HCL attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ terraform {
 
 provider "circleci" {
   host = "https://circleci.com/api/v2"
-  #key  = "*****" # here you set you CircleCI API Key
+  #key         = "*****" # here you set you CircleCI API Key
+  #runner_host = "https://runner.circleci.com" # required for self-hosted runner resources on CircleCI server
 }
 ```
 Start defining Data Sources and Resources. For example:

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,8 @@ description: |-
 ```terraform
 provider "circleci" {
   host = "https://circleci.com/api/v2"
-  #key  = "*****"
+  #key         = "*****"
+  #runner_host = "https://runner.circleci.com" # required for self-hosted runner resources on CircleCI server
 }
 ```
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,4 +1,5 @@
 provider "circleci" {
   host = "https://circleci.com/api/v2"
-  #key  = "*****"
+  #key         = "*****"
+  #runner_host = "https://runner.circleci.com" # required for self-hosted runner resources on CircleCI server
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -122,7 +122,7 @@ func (p *CircleCiProvider) Configure(ctx context.Context, req provider.Configure
 	}
 
 	if !config.RunnerHost.IsNull() {
-		runner_host = config.Host.ValueString()
+		runner_host = config.RunnerHost.ValueString()
 	}
 
 	// If host is missing, return

--- a/internal/provider/provider_runner_host_test.go
+++ b/internal/provider/provider_runner_host_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccProvider_RunnerHostHCL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, `{"items":[{"id":"11111111-2222-3333-4444-555555555555","resource_class":"ns/rc","description":""}]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := fmt.Sprintf(`
+provider "circleci" {
+  host        = "http://127.0.0.1:1"
+  runner_host = %q
+  key         = "fake"
+}
+data "circleci_runner_resource_class" "t" {
+  organization_id = "00000000-1111-2222-3333-444444444444"
+  resource_class  = "ns/rc"
+}
+`, srv.URL)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps:                    []resource.TestStep{{Config: cfg}},
+	})
+}


### PR DESCRIPTION
The HCL `runner_host` attribute was silently aliased to host because the assignment read config.Host instead of config.RunnerHost. Setting it via `CIRCLE_RUNNER_HOST` env var was unaffected.