### PR TITLE
fix(circleci_project): in-place updates no longer cascade replacement; fix pr_only_branch_overrides quoting

### DIFF
--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -278,7 +278,15 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 		prElements := plan.PROnlyBranchOverrides.Elements()
 		branches := make([]string, len(prElements))
 		for index, branch := range prElements {
-			branches[index] = branch.String()
+			v, ok := branch.(types.String)
+			if !ok {
+				resp.Diagnostics.AddError(
+					"Unexpected type in pr_only_branch_overrides",
+					fmt.Sprintf("expected types.String, got %T", branch),
+				)
+				return
+			}
+			branches[index] = v.ValueString()
 		}
 		newAdvancedSettings.PROnlyBranchOverrides = branches
 	}
@@ -435,7 +443,15 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 	prOnlybranchOverrides := make([]string, len(plan.PROnlyBranchOverrides.Elements()))
 	for index, elem := range plan.PROnlyBranchOverrides.Elements() {
-		prOnlybranchOverrides[index] = elem.String()
+		v, ok := elem.(types.String)
+		if !ok {
+			resp.Diagnostics.AddError(
+				"Unexpected type in pr_only_branch_overrides",
+				fmt.Sprintf("expected types.String, got %T", elem),
+			)
+			return
+		}
+		prOnlybranchOverrides[index] = v.ValueString()
 	}
 	advanceSettings := project.AdvanceSettings{
 		AutocancelBuilds:          plan.AutoCancelBuilds.ValueBoolPointer(),

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -71,6 +73,9 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The unique identifier of the project.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "The name of the project repository. Changing this value forces a new resource to be created.",
@@ -82,14 +87,23 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"slug": schema.StringAttribute{
 				MarkdownDescription: "The project slug in the format `vcs-type/org-name/repo-name`.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"organization_name": schema.StringAttribute{
 				MarkdownDescription: "The name of the owning organization.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"organization_slug": schema.StringAttribute{
 				MarkdownDescription: "The slug of the owning organization.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"organization_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the organization that owns this project. Changing this value forces a new resource to be created.",
@@ -101,34 +115,55 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"vcs_info_url": schema.StringAttribute{
 				MarkdownDescription: "The VCS URL of the project repository.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"vcs_info_provider": schema.StringAttribute{
 				MarkdownDescription: "The VCS provider (e.g., `github`, `bitbucket`).",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"vcs_info_default_branch": schema.StringAttribute{
 				MarkdownDescription: "The default branch of the project repository.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"auto_cancel_builds": schema.BoolAttribute{
 				MarkdownDescription: "Whether to automatically cancel redundant builds.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"build_fork_prs": schema.BoolAttribute{
 				MarkdownDescription: "Whether to build pull requests from forked repositories.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"disable_ssh": schema.BoolAttribute{
 				MarkdownDescription: "Whether to disable SSH access to builds.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"forks_receive_secret_env_vars": schema.BoolAttribute{
 				MarkdownDescription: "Whether forked pull requests can access secret environment variables.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			/*"oss": schema.BoolAttribute{
 				MarkdownDescription: "Whether the project is open source.",
@@ -138,22 +173,34 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				MarkdownDescription: "Whether to set GitHub commit status on builds.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"setup_workflows": schema.BoolAttribute{
 				MarkdownDescription: "Whether setup workflows are enabled.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"write_settings_requires_admin": schema.BoolAttribute{
 				MarkdownDescription: "Whether admin permissions are required to change project settings.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"pr_only_branch_overrides": schema.ListAttribute{
 				MarkdownDescription: "List of branches that override the PR-only build setting.",
 				Optional:            true,
 				Computed:            true,
 				ElementType:         types.StringType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## What this fixes

Two bugs in `circleci_project` that combine to make in-place updates unsafe.

### 1. Cascading replacement on benign edits

Changing any field on a `circleci_project` (e.g. `auto_cancel_builds = false`) plans as a destructive cascade:

```
Plan: 4 to add, 6 to change, 4 to destroy.

# circleci_context_restriction.X            must be replaced
# circleci_project_environment_variable.Y   must be replaced
# circleci_webhook.Z                        must be replaced
```

Any resource referencing `circleci_project.X.id` or `.slug` (context restrictions, project env vars, webhooks scoped to the project) gets destroyed and recreated. Project env vars carry secrets, so this **silently drops customer secrets** on apply.

**Cause:** `Computed` attributes including `id` and `slug` had no `UseStateForUnknown` plan modifier, so the framework marked them `Unknown` during plan whenever any other field changed. Dependents whose `RequiresReplace` fields reference the project then had to replace.

**Fix:** add `UseStateForUnknown` to all `Computed` attributes. Same pattern is already used in `runner_resource_class_resource.go` in this repo.

### 2. `pr_only_branch_overrides` elements get double-quoted (Fixes #59)

```hcl
pr_only_branch_overrides = ["main"]
```

…fails apply with:

```
Error: Provider produced inconsistent result after apply
.pr_only_branch_overrides[0]: was cty.StringVal("main"),
but now cty.StringVal("\"main\"").
```

**Cause:** `Create` and `Update` extract list elements via `branch.String()`, which returns the Terraform-syntax representation (literally `"main"` including the quotes). The quoted strings were sent to the API and stored.

**Fix:** use `elem.(types.String).ValueString()` instead — the same pattern used for individual string attributes in this provider.

#61 proposed the same extraction fix bundled with a `ListAttribute` → `SetAttribute` schema change. This PR keeps the existing list type to avoid breaking existing HCL; the type-shape decision can be a separate follow-up.

## Why both in one PR

Fix 1 alone exposes Fix 2: removing the cascade means `Update` actually runs (it didn't before, because every change destroyed and recreated), which immediately trips the quoting bug. Shipping Fix 1 without Fix 2 just moves the failure from "destructive plan" to "apply error".

## Testing

Tested locally against a CircleCI standalone organization with a project, two project env vars, a context restriction, and a webhook.

Before: toggling `auto_cancel_builds` plans as `4 add / 6 change / 4 destroy`. Forcing past that hits the `pr_only_branch_overrides` 400.

After: same toggle plans as `0 add / 1 change / 0 destroy`, applies clean, re-plan reports `No changes`. Setting `pr_only_branch_overrides = ["main", "develop"]` and applying stores the values verbatim with no embedded quotes.

## Migration note

Existing projects whose API state has the quoted form stored (`["\"main\""]`) will continue to read that way until cleaned up. Setting `pr_only_branch_overrides` explicitly in HCL and applying once overwrites the API state via the corrected `Update` path.

Closes #59.