### PR TITLE
update context_environment_variable value in-place without replacement

### DIFF
--- a/internal/provider/context_environment_variable_resource.go
+++ b/internal/provider/context_environment_variable_resource.go
@@ -61,12 +61,9 @@ func (r *contextEnvironmentVariableResource) Schema(_ context.Context, _ resourc
 				},
 			},
 			"value": schema.StringAttribute{
-				MarkdownDescription: "The value of the environment variable. Changing this value forces a new resource to be created.",
+				MarkdownDescription: "The value of the environment variable.",
 				Required:            true,
 				Sensitive:           true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"updated_at": schema.StringAttribute{
 				MarkdownDescription: "The timestamp when the environment variable was last updated.",
@@ -178,8 +175,29 @@ func (r *contextEnvironmentVariableResource) Read(ctx context.Context, req resou
 	}
 }
 
-// Update is a no-op: all mutable attributes use RequiresReplace(), so changes run as delete+create.
+// Update calls the PUT upsert endpoint, which atomically overwrites the value in place
 func (r *contextEnvironmentVariableResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan contextEnvironmentVariableResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updated, err := r.client.Create(ctx, plan.ContextId.ValueString(), plan.Value.ValueString(), plan.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating CircleCI context environment variable",
+			"Could not update CircleCI context environment variable, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	plan.CreatedAt = types.StringValue(updated.CreatedAt.Format("2006-01-02T15:04:05.000Z"))
+	plan.UpdatedAt = types.StringValue(updated.UpdatedAt.Format("2006-01-02T15:04:05.000Z"))
+
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
 }
 
 // Delete deletes the resource and removes the Terraform state on success.


### PR DESCRIPTION
Currently, circleci_context_environment_variable has RequiresReplace() on the value attribute, which causes Terraform to delete and recreate the resource whenever the value changes. This creates a brief window between the delete and recreate steps where any CI jobs that start and attempt to use the context will fail to find the environment variable.

This PR removes RequiresReplace() from value and implements a proper Update function that calls the existing `PUT /context/{id}/environment-variable/{name}` endpoint directly. 

### Side Note

I doubled checked the internals of this endpoint, and it does in fact perform an atomic update. So there will be no downtime when updating this resource.

### Testing

I tested changing it by initially applying:
```
resource "circleci_context_environment_variable" "test" {
  context_id = "<context-id>"
  name       = "TEST_VAR"
  value      = "value_first"
}
```

And then:
```
resource "circleci_context_environment_variable" "test" {
  context_id = "<context-id>"
  name       = "TEST_VAR"
  value      = "value_second"
}
```

And verified in the UI that the context environment variable values were replaced correctly.

And also verified on the terraform side that the second apply only logs:
```
circleci_context_environment_variable.test: Modifying... [name=TEST_VAR]
circleci_context_environment_variable.test: Modifications complete after 1s [name=TEST_VAR]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed
```