### PR TITLE
Bump circleci-sdk-go to fix project creation 404 for org-owned repos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.1
 
 require (
-	github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260416170840-e18c6bfc124e
+	github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260624141258-5c9c65658b97
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260416170840-e18c6bfc124e h1:KZK+/4ApYq9R1R12tsinXC7DWIuud87//o6bRD1bNYI=
-github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260416170840-e18c6bfc124e/go.mod h1:3qBhtUAWi7ptXoop4cQkStrwfldxRwDFYM+k43fMaa0=
+github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260624141258-5c9c65658b97 h1:wwKNS8/PqjCIdvl8d09TQ3LH9oXzly3Nlak3pz8/vWg=
+github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260624141258-5c9c65658b97/go.mod h1:3qBhtUAWi7ptXoop4cQkStrwfldxRwDFYM+k43fMaa0=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rWPdisA5ynNEsoARbiCBOyGcJM4/OzsM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.1 h1:Sz1JIXEcSfhz7fUi7xHnhpIE0thVASYjvosApmHuD2k=


### PR DESCRIPTION
## Summary

- Updates `circleci-sdk-go` from `20260416` to `20260624` to pick up [PR #43](https://github.com/CircleCI-Public/circleci-sdk-go/pull/43)
- Fixes the `circleci_project` resource returning 404 on create for org-owned repos ([#102](https://github.com/CircleCI-Public/terraform-provider-circleci/issues/102))
- Root cause: the SDK was using `user.Login` (token owner's personal username) instead of the org name from the project slug when building the v1.1 follow URL

## Test plan

- [x] `go test ./... -short` — all tests pass
- [x] `go build ./...` — builds successfully
- [x] `terraform apply` with `circleci_project` for an org-owned repo no longer returns 404
- [x] Existing project resources continue to work (read/import/settings)