### PR TITLE
fix: write pr_only_branch_overrides unquoted

### DIFF
--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -228,10 +228,10 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	if !plan.PROnlyBranchOverrides.IsNull() {
-		prElements := plan.PROnlyBranchOverrides.Elements()
-		branches := make([]string, len(prElements))
-		for index, branch := range prElements {
-			branches[index] = branch.String()
+		var branches []string
+		resp.Diagnostics.Append(plan.PROnlyBranchOverrides.ElementsAs(ctx, &branches, false)...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
 		newAdvancedSettings.PROnlyBranchOverrides = branches
 	}
@@ -386,9 +386,12 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	prOnlybranchOverrides := make([]string, len(plan.PROnlyBranchOverrides.Elements()))
-	for index, elem := range plan.PROnlyBranchOverrides.Elements() {
-		prOnlybranchOverrides[index] = elem.String()
+	var prOnlybranchOverrides []string
+	if !plan.PROnlyBranchOverrides.IsNull() {
+		resp.Diagnostics.Append(plan.PROnlyBranchOverrides.ElementsAs(ctx, &prOnlybranchOverrides, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 	advanceSettings := project.AdvanceSettings{
 		AutocancelBuilds:          plan.AutoCancelBuilds.ValueBoolPointer(),

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -7,6 +7,8 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -331,6 +333,75 @@ func TestAccGithubProjectOrgUpdateResource(t *testing.T) {
 			// Delete testing automatically occurs in TestCase
 		},
 	})
+}
+
+// Regression test for pr_only_branch_overrides being written back JSON-quoted.
+//
+// The other tests in this file assert only ListSizeExact on this attribute, and a quoted element
+// still has length 1 - so a value of `"main"` (with literal quote characters) satisfied them. These
+// assertions are on the element values, which is what actually distinguishes the two.
+//
+// A quoted pattern matches no branch, so on a project with build-prs-only enabled the override
+// silently stops applying and the branch it named stops building.
+func TestAccProjectResourcePROnlyBranchOverrides(t *testing.T) {
+	projectName := rand.Text()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create: the values sent must survive the round trip unquoted.
+			{
+				Config: testAccProjectResourceConfigWithBranchOverrides(
+					projectName,
+					"3ddcf1d1-7f5f-4139-8cef-71ad0921a968",
+					[]string{"main", "release/.*"},
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_project.test_project",
+						tfjsonpath.New("pr_only_branch_overrides"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("main"),
+							knownvalue.StringExact("release/.*"),
+						}),
+					),
+				},
+			},
+			// Update: the same conversion exists on the update path, so cover it separately.
+			{
+				Config: testAccProjectResourceConfigWithBranchOverrides(
+					projectName,
+					"3ddcf1d1-7f5f-4139-8cef-71ad0921a968",
+					[]string{"main", "release/.*", "hotfix/.*"},
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_project.test_project",
+						tfjsonpath.New("pr_only_branch_overrides"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("main"),
+							knownvalue.StringExact("release/.*"),
+							knownvalue.StringExact("hotfix/.*"),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccProjectResourceConfigWithBranchOverrides(name, organization_id string, overrides []string) string {
+	quoted := make([]string, len(overrides))
+	for index, override := range overrides {
+		quoted[index] = strconv.Quote(override)
+	}
+	return fmt.Sprintf(`
+resource "circleci_project" "test_project" {
+  name                     = %[1]q
+  organization_id          = %[2]q
+  pr_only_branch_overrides = [%[3]s]
+}
+`, name, organization_id, strings.Join(quoted, ", "))
 }
 
 func testAccProjectResourceConfig(name, organization_id string, auto_cancel_builds bool, build_forked_prs bool) string {


### PR DESCRIPTION
### The bug

`types.String.String()` returns the Terraform-quoted *representation* of a value, not the value. Both the create and update paths build the outgoing `PROnlyBranchOverrides` slice with it:

```go
// internal/provider/project_resource.go (Create)
branches[index] = branch.String()

// internal/provider/project_resource.go (Update)
prOnlybranchOverrides[index] = elem.String()
```

So every pattern reaches the API wrapped in literal quote characters. Given this config:

```hcl
pr_only_branch_overrides = ["main", "release/.*"]
```

the project ends up with:

```json
["\"main\"", "\"release/.*\""]
```

### Why it matters

A quoted pattern matches no branch. On a project with **build-prs-only** enabled, the override silently stops applying and the branch it named stops building — no error from Terraform, none from the API.

Applying to a project that already had overrides rewrites the **existing** entries too, not just the ones being added. We hit this on three repositories: their pre-existing `master` / `main` / `gh-readonly-queue.*` entries were all rewritten quoted in one apply, and pushes to those default branches stopped producing pipelines until we restored the values by hand through `PATCH /api/v2/project/{slug}/settings`.

The read paths are already correct (`types.StringValue(elem)`), and that is what makes it persistent rather than self-healing: the provider writes quoted, reads back unquoted, so every subsequent plan shows a diff that applying cannot settle.

### The fix

Use `ElementsAs`, the framework-idiomatic conversion from `types.List` to `[]string`. It yields the underlying values and reports element-type problems as diagnostics instead of silently producing the wrong text. The update path keeps its null check, so a config that omits the attribute still sends an empty list exactly as before.

### Why the tests did not catch it

The existing assertions on this attribute are `knownvalue.ListSizeExact(...)`, and a quoted element still has length 1 — so the bug satisfied them. The test configs also never set `pr_only_branch_overrides`, so the write path was not exercised at all.

The added acceptance test sets the attribute explicitly and asserts the element **values** with `knownvalue.ListExact`, across both create and update (the update path has its own copy of the conversion).

### Verification

- `go build ./...` and `go vet ./internal/provider/` are clean; `gofmt` reports nothing.
- The new test compiles and skips correctly without `TF_ACC`.
- **I have not run the acceptance suite** — it needs credentials for the CircleCI test organisation, which I do not have. The fix itself was confirmed against a live project by reproducing the quoting through the provider and then writing the correct values via the same API the SDK uses.
