### PR TITLE
Test pr 120

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -41,7 +41,7 @@ resource "circleci_project" "example" {
 - `build_fork_prs` (Boolean) Whether to build pull requests from forked repositories.
 - `disable_ssh` (Boolean) Whether to disable SSH access to builds.
 - `forks_receive_secret_env_vars` (Boolean) Whether forked pull requests can access secret environment variables.
-- `pr_only_branch_overrides` (List of String) List of branches that override the PR-only build setting.
+- `pr_only_branch_overrides` (Set of String) Set of branches that override the PR-only build setting.
 - `set_github_status` (Boolean) Whether to set GitHub commit status on builds.
 - `setup_workflows` (Boolean) Whether setup workflows are enabled.
 - `write_settings_requires_admin` (Boolean) Whether admin permissions are required to change project settings.

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -228,10 +228,10 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	if !plan.PROnlyBranchOverrides.IsNull() {
-		prElements := plan.PROnlyBranchOverrides.Elements()
-		branches := make([]string, len(prElements))
-		for index, branch := range prElements {
-			branches[index] = branch.String()
+		var branches []string
+		resp.Diagnostics.Append(plan.PROnlyBranchOverrides.ElementsAs(ctx, &branches, false)...)
+		if resp.Diagnostics.HasError() {
+			return
 		}
 		newAdvancedSettings.PROnlyBranchOverrides = branches
 	}
@@ -386,9 +386,12 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	prOnlybranchOverrides := make([]string, len(plan.PROnlyBranchOverrides.Elements()))
-	for index, elem := range plan.PROnlyBranchOverrides.Elements() {
-		prOnlybranchOverrides[index] = elem.String()
+	var prOnlybranchOverrides []string
+	if !plan.PROnlyBranchOverrides.IsNull() {
+		resp.Diagnostics.Append(plan.PROnlyBranchOverrides.ElementsAs(ctx, &prOnlybranchOverrides, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 	advanceSettings := project.AdvanceSettings{
 		AutocancelBuilds:          plan.AutoCancelBuilds.ValueBoolPointer(),

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -45,7 +45,7 @@ type projectResourceModel struct {
 	SetGithubStatus            types.Bool `tfsdk:"set_github_status"`
 	SetupWorkflows             types.Bool `tfsdk:"setup_workflows"`
 	WriteSettingsRequiresAdmin types.Bool `tfsdk:"write_settings_requires_admin"`
-	PROnlyBranchOverrides      types.List `tfsdk:"pr_only_branch_overrides"`
+	PROnlyBranchOverrides      types.Set  `tfsdk:"pr_only_branch_overrides"`
 }
 
 // NewProjectResource is a helper function to simplify the provider implementation.
@@ -149,8 +149,8 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:            true,
 				Computed:            true,
 			},
-			"pr_only_branch_overrides": schema.ListAttribute{
-				MarkdownDescription: "List of branches that override the PR-only build setting.",
+			"pr_only_branch_overrides": schema.SetAttribute{
+				MarkdownDescription: "Set of branches that override the PR-only build setting.",
 				Optional:            true,
 				Computed:            true,
 				ElementType:         types.StringType,
@@ -227,7 +227,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 		newAdvancedSettings.WriteSettingsRequiresAdmin = plan.WriteSettingsRequiresAdmin.ValueBoolPointer()
 	}
 
-	if !plan.PROnlyBranchOverrides.IsNull() {
+	if !plan.PROnlyBranchOverrides.IsNull() && !plan.PROnlyBranchOverrides.IsUnknown() {
 		var branches []string
 		resp.Diagnostics.Append(plan.PROnlyBranchOverrides.ElementsAs(ctx, &branches, false)...)
 		if resp.Diagnostics.HasError() {
@@ -278,7 +278,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	for index, elem := range newProjectSettings.Advanced.PROnlyBranchOverrides {
 		listStringValuesBanches[index] = types.StringValue(elem)
 	}
-	plan.PROnlyBranchOverrides, diags = types.ListValue(
+	plan.PROnlyBranchOverrides, diags = types.SetValue(
 		types.StringType,
 		listStringValuesBanches,
 	)
@@ -362,8 +362,8 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 	for index, elem := range projectSettings.Advanced.PROnlyBranchOverrides {
 		pROnlyBranchOverridesAttributeValues[index] = types.StringValue(elem)
 	}
-	PROnlyBranchOverridesListValue, _ := types.ListValue(types.StringType, pROnlyBranchOverridesAttributeValues)
-	projectState.PROnlyBranchOverrides = PROnlyBranchOverridesListValue
+	PROnlyBranchOverridesSetValue, _ := types.SetValue(types.StringType, pROnlyBranchOverridesAttributeValues)
+	projectState.PROnlyBranchOverrides = PROnlyBranchOverridesSetValue
 
 	// Set state
 	diags = resp.State.Set(ctx, &projectState)
@@ -387,7 +387,7 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 	var prOnlybranchOverrides []string
-	if !plan.PROnlyBranchOverrides.IsNull() {
+	if !plan.PROnlyBranchOverrides.IsNull() && !plan.PROnlyBranchOverrides.IsUnknown() {
 		resp.Diagnostics.Append(plan.PROnlyBranchOverrides.ElementsAs(ctx, &prOnlybranchOverrides, false)...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -431,8 +431,8 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		for index, elem := range projectSettings.Advanced.PROnlyBranchOverrides {
 			pROnlyBranchOverridesAttributeValues[index] = types.StringValue(elem)
 		}
-		PROnlyBranchOverridesListValue, _ := types.ListValue(types.StringType, pROnlyBranchOverridesAttributeValues)
-		state.PROnlyBranchOverrides = PROnlyBranchOverridesListValue
+		PROnlyBranchOverridesSetValue, _ := types.SetValue(types.StringType, pROnlyBranchOverridesAttributeValues)
+		state.PROnlyBranchOverrides = PROnlyBranchOverridesSetValue
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -7,6 +7,8 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -331,6 +333,75 @@ func TestAccGithubProjectOrgUpdateResource(t *testing.T) {
 			// Delete testing automatically occurs in TestCase
 		},
 	})
+}
+
+// Regression test for pr_only_branch_overrides being written back JSON-quoted.
+//
+// The other tests in this file assert only ListSizeExact on this attribute, and a quoted element
+// still has length 1 - so a value of `"main"` (with literal quote characters) satisfied them. These
+// assertions are on the element values, which is what actually distinguishes the two.
+//
+// A quoted pattern matches no branch, so on a project with build-prs-only enabled the override
+// silently stops applying and the branch it named stops building.
+func TestAccProjectResourcePROnlyBranchOverrides(t *testing.T) {
+	projectName := rand.Text()
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create: the values sent must survive the round trip unquoted.
+			{
+				Config: testAccProjectResourceConfigWithBranchOverrides(
+					projectName,
+					"3ddcf1d1-7f5f-4139-8cef-71ad0921a968",
+					[]string{"main", "release/.*"},
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_project.test_project",
+						tfjsonpath.New("pr_only_branch_overrides"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("main"),
+							knownvalue.StringExact("release/.*"),
+						}),
+					),
+				},
+			},
+			// Update: the same conversion exists on the update path, so cover it separately.
+			{
+				Config: testAccProjectResourceConfigWithBranchOverrides(
+					projectName,
+					"3ddcf1d1-7f5f-4139-8cef-71ad0921a968",
+					[]string{"main", "release/.*", "hotfix/.*"},
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"circleci_project.test_project",
+						tfjsonpath.New("pr_only_branch_overrides"),
+						knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.StringExact("main"),
+							knownvalue.StringExact("release/.*"),
+							knownvalue.StringExact("hotfix/.*"),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccProjectResourceConfigWithBranchOverrides(name, organization_id string, overrides []string) string {
+	quoted := make([]string, len(overrides))
+	for index, override := range overrides {
+		quoted[index] = strconv.Quote(override)
+	}
+	return fmt.Sprintf(`
+resource "circleci_project" "test_project" {
+  name                     = %[1]q
+  organization_id          = %[2]q
+  pr_only_branch_overrides = [%[3]s]
+}
+`, name, organization_id, strings.Join(quoted, ", "))
 }
 
 func testAccProjectResourceConfig(name, organization_id string, auto_cancel_builds bool, build_forked_prs bool) string {

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -61,7 +61,7 @@ func TestAccCircleCiProjectResource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"circleci_project.test_project",
 						tfjsonpath.New("pr_only_branch_overrides"),
-						knownvalue.ListSizeExact(1),
+						knownvalue.SetSizeExact(1),
 					),
 				},
 			},
@@ -184,7 +184,7 @@ func TestAccCircleCiProjectOrgUpdateResource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"circleci_project.test_project",
 						tfjsonpath.New("pr_only_branch_overrides"),
-						knownvalue.ListSizeExact(1),
+						knownvalue.SetSizeExact(1),
 					),
 				},
 			},
@@ -226,7 +226,7 @@ func TestAccCircleCiProjectOrgUpdateResource(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"circleci_project.test_project",
 						tfjsonpath.New("pr_only_branch_overrides"),
-						knownvalue.ListSizeExact(1),
+						knownvalue.SetSizeExact(1),
 					),
 				},
 			},
@@ -337,7 +337,7 @@ func TestAccGithubProjectOrgUpdateResource(t *testing.T) {
 
 // Regression test for pr_only_branch_overrides being written back JSON-quoted.
 //
-// The other tests in this file assert only ListSizeExact on this attribute, and a quoted element
+// The other tests in this file assert only SetSizeExact on this attribute, and a quoted element
 // still has length 1 - so a value of `"main"` (with literal quote characters) satisfied them. These
 // assertions are on the element values, which is what actually distinguishes the two.
 //
@@ -360,7 +360,7 @@ func TestAccProjectResourcePROnlyBranchOverrides(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"circleci_project.test_project",
 						tfjsonpath.New("pr_only_branch_overrides"),
-						knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.SetExact([]knownvalue.Check{
 							knownvalue.StringExact("main"),
 							knownvalue.StringExact("release/.*"),
 						}),
@@ -378,7 +378,7 @@ func TestAccProjectResourcePROnlyBranchOverrides(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"circleci_project.test_project",
 						tfjsonpath.New("pr_only_branch_overrides"),
-						knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.SetExact([]knownvalue.Check{
 							knownvalue.StringExact("main"),
 							knownvalue.StringExact("release/.*"),
 							knownvalue.StringExact("hotfix/.*"),


### PR DESCRIPTION
This PR references https://github.com/CircleCI-Public/terraform-provider-circleci/pull/120 and is built on top of it

fix: model pr_only_branch_overrides as a set and guard unknown values
Changes
- check IsUnknown for PROnlyBranchOverrides on create and update since an attribute the config omits is planned as unknown
- Make PROnlyBranchOverrides a set instead of list for ordered fields