### PR TITLE
feat: support typed circleci_trigger parameters (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 ## 0.1.0 (Unreleased)
 
 FEATURES:
+
+ENHANCEMENTS:
+
+* resource/circleci_trigger: `parameters` now accepts typed values (strings, booleans, and numbers) instead of only strings, so scheduled triggers can supply boolean and numeric pipeline parameters ([#122](https://github.com/CircleCI-Public/terraform-provider-circleci/issues/122)).
+* data-source/circleci_trigger: `parameters` now reports typed values (strings, booleans, and numbers).

--- a/docs/data-sources/trigger.md
+++ b/docs/data-sources/trigger.md
@@ -42,4 +42,4 @@ data "circleci_trigger" "example" {
 - `event_source_schedule_attribution_actor` (String) The actor attributed to scheduled pipeline runs.
 - `event_source_schedule_cron_expression` (String) The cron expression for scheduled triggers.
 - `event_source_webhook_url` (String) The webhook URL for webhook-based triggers.
-- `parameters` (Map of String) The default pipeline parameters for this trigger.
+- `parameters` (Dynamic) The default pipeline parameters for this trigger. Values may be strings, booleans, or numbers.

--- a/docs/resources/trigger.md
+++ b/docs/resources/trigger.md
@@ -35,8 +35,12 @@ resource "circleci_trigger" "scheduled" {
   config_ref                               = "main"
   event_source_schedule_cron_expression    = "0 2 * * *"
   event_source_schedule_attribution_actor  = "system"
-  parameters                               = {
-    run_nightly_foo = "true"
+
+  # Parameter values may be strings, booleans, or numbers to match the type of
+  # the corresponding pipeline parameter.
+  parameters = {
+    run_nightly_foo = true
+    retries         = 3
     branch          = "main"
   }
 }
@@ -76,7 +80,7 @@ resource "circleci_trigger" "webhook" {
 - `event_source_schedule_attribution_actor` (String) Attribution actor for the schedule event source. Required when event_source_provider is schedule. Must be "system" or "current".
 - `event_source_schedule_cron_expression` (String) Cron expression for the schedule event source. Required when event_source_provider is schedule.
 - `event_source_web_hook_sender` (String) The webhook sender identifier. Required when `event_source_provider` is `webhook`.
-- `parameters` (Map of String) Pipeline parameters to pass when running pipelines from this trigger. Only supported when `event_source_provider` is `schedule`.
+- `parameters` (Dynamic) Pipeline parameters to pass when running pipelines from this trigger. Only supported when `event_source_provider` is `schedule`. Values may be strings, booleans, or numbers to match the type of the corresponding pipeline parameter, e.g. `parameters = { deploy_enabled = true, retries = 3, branch = "main" }`.
 
 ### Read-Only
 

--- a/examples/resources/circleci_trigger/scheduled.tf
+++ b/examples/resources/circleci_trigger/scheduled.tf
@@ -7,8 +7,11 @@ resource "circleci_trigger" "scheduled" {
   config_ref                              = "main"
   event_source_schedule_cron_expression   = "0 2 * * *"
   event_source_schedule_attribution_actor = "system"
+  # Parameter values may be strings, booleans, or numbers to match the type of
+  # the corresponding pipeline parameter.
   parameters = {
-    run_nightly_foo = "true"
+    run_nightly_foo = true
+    retries         = 3
     branch          = "main"
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.1
 
 require (
-	github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260624141258-5c9c65658b97
+	github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260811125741-4ead4cd94734
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260624141258-5c9c65658b97 h1:wwKNS8/PqjCIdvl8d09TQ3LH9oXzly3Nlak3pz8/vWg=
-github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260624141258-5c9c65658b97/go.mod h1:3qBhtUAWi7ptXoop4cQkStrwfldxRwDFYM+k43fMaa0=
+github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260811125741-4ead4cd94734 h1:Lly2nJScbKuQS32XKpLEM1q9BvQFnyJ732ENeWcXivw=
+github.com/CircleCI-Public/circleci-sdk-go v0.0.0-20260811125741-4ead4cd94734/go.mod h1:3qBhtUAWi7ptXoop4cQkStrwfldxRwDFYM+k43fMaa0=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rWPdisA5ynNEsoARbiCBOyGcJM4/OzsM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.1 h1:Sz1JIXEcSfhz7fUi7xHnhpIE0thVASYjvosApmHuD2k=

--- a/internal/provider/trigger_data_source.go
+++ b/internal/provider/trigger_data_source.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/CircleCI-Public/circleci-sdk-go/trigger"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -22,20 +21,20 @@ var (
 
 // TriggerDataSourceModel maps the output schema.
 type triggerDataSourceModel struct {
-	Id                                  types.String `tfsdk:"id"`
-	ProjectId                           types.String `tfsdk:"project_id"`
-	CreatedAt                           types.String `tfsdk:"created_at"`
-	CheckoutRef                         types.String `tfsdk:"checkout_ref"`
-	EventName                           types.String `tfsdk:"event_name"`
-	EventPreset                         types.String `tfsdk:"event_preset"`
-	EventSourceProvider                 types.String `tfsdk:"event_source_provider"`
-	EventSourceRepositoryName           types.String `tfsdk:"event_source_repository_name"`
-	EventSourceRepositoryExternalId     types.String `tfsdk:"event_source_repository_external_id"`
-	EventSourceWebHookUrl               types.String `tfsdk:"event_source_webhook_url"`
-	EventSourceScheduleCronExpression   types.String `tfsdk:"event_source_schedule_cron_expression"`
-	EventSourceScheduleAttributionActor types.String `tfsdk:"event_source_schedule_attribution_actor"`
-	Disabled                            types.Bool   `tfsdk:"disabled"`
-	Parameters                          types.Map    `tfsdk:"parameters"`
+	Id                                  types.String  `tfsdk:"id"`
+	ProjectId                           types.String  `tfsdk:"project_id"`
+	CreatedAt                           types.String  `tfsdk:"created_at"`
+	CheckoutRef                         types.String  `tfsdk:"checkout_ref"`
+	EventName                           types.String  `tfsdk:"event_name"`
+	EventPreset                         types.String  `tfsdk:"event_preset"`
+	EventSourceProvider                 types.String  `tfsdk:"event_source_provider"`
+	EventSourceRepositoryName           types.String  `tfsdk:"event_source_repository_name"`
+	EventSourceRepositoryExternalId     types.String  `tfsdk:"event_source_repository_external_id"`
+	EventSourceWebHookUrl               types.String  `tfsdk:"event_source_webhook_url"`
+	EventSourceScheduleCronExpression   types.String  `tfsdk:"event_source_schedule_cron_expression"`
+	EventSourceScheduleAttributionActor types.String  `tfsdk:"event_source_schedule_attribution_actor"`
+	Disabled                            types.Bool    `tfsdk:"disabled"`
+	Parameters                          types.Dynamic `tfsdk:"parameters"`
 }
 
 // NewTriggerDataSource is a helper function to simplify the provider implementation.
@@ -110,9 +109,8 @@ func (d *TriggerDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				MarkdownDescription: "The actor attributed to scheduled pipeline runs.",
 				Computed:            true,
 			},
-			"parameters": schema.MapAttribute{
-				MarkdownDescription: "The default pipeline parameters for this trigger.",
-				ElementType:         types.StringType,
+			"parameters": schema.DynamicAttribute{
+				MarkdownDescription: "The default pipeline parameters for this trigger. Values may be strings, booleans, or numbers.",
 				Computed:            true,
 			},
 		},
@@ -153,12 +151,8 @@ func (d *TriggerDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	// Map parameters from API response
-	paramAttrs := make(map[string]attr.Value, len(retrievedTrigger.Parameters))
-	for k, v := range retrievedTrigger.Parameters {
-		paramAttrs[k] = types.StringValue(v)
-	}
-	parameters, paramDiags := types.MapValue(types.StringType, paramAttrs)
+	// Map parameters from API response, preserving each value's JSON type.
+	parameters, paramDiags := triggerParametersFromAPI(retrievedTrigger.Parameters)
 	resp.Diagnostics.Append(paramDiags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/trigger_resource.go
+++ b/internal/provider/trigger_resource.go
@@ -5,7 +5,9 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/CircleCI-Public/circleci-sdk-go/common"
@@ -32,23 +34,23 @@ var (
 
 // triggerResourceModel maps the output schema.
 type triggerResourceModel struct {
-	Id                                  types.String `tfsdk:"id"`
-	ProjectId                           types.String `tfsdk:"project_id"`
-	PipelineId                          types.String `tfsdk:"pipeline_id"`
-	CreatedAt                           types.String `tfsdk:"created_at"`
-	CheckoutRef                         types.String `tfsdk:"checkout_ref"`
-	ConfigRef                           types.String `tfsdk:"config_ref"`
-	EventSourceProvider                 types.String `tfsdk:"event_source_provider"`
-	EventSourceRepoFullName             types.String `tfsdk:"event_source_repo_full_name"`
-	EventSourceRepoExternalId           types.String `tfsdk:"event_source_repo_external_id"`
-	EventSourceWebHookUrl               types.String `tfsdk:"event_source_web_hook_url"`
-	EventSourceWebHookSender            types.String `tfsdk:"event_source_web_hook_sender"`
-	EventSourceScheduleCronExpression   types.String `tfsdk:"event_source_schedule_cron_expression"`
-	EventSourceScheduleAttributionActor types.String `tfsdk:"event_source_schedule_attribution_actor"`
-	EventPreset                         types.String `tfsdk:"event_preset"`
-	EventName                           types.String `tfsdk:"event_name"`
-	Disabled                            types.Bool   `tfsdk:"disabled"`
-	Parameters                          types.Map    `tfsdk:"parameters"`
+	Id                                  types.String  `tfsdk:"id"`
+	ProjectId                           types.String  `tfsdk:"project_id"`
+	PipelineId                          types.String  `tfsdk:"pipeline_id"`
+	CreatedAt                           types.String  `tfsdk:"created_at"`
+	CheckoutRef                         types.String  `tfsdk:"checkout_ref"`
+	ConfigRef                           types.String  `tfsdk:"config_ref"`
+	EventSourceProvider                 types.String  `tfsdk:"event_source_provider"`
+	EventSourceRepoFullName             types.String  `tfsdk:"event_source_repo_full_name"`
+	EventSourceRepoExternalId           types.String  `tfsdk:"event_source_repo_external_id"`
+	EventSourceWebHookUrl               types.String  `tfsdk:"event_source_web_hook_url"`
+	EventSourceWebHookSender            types.String  `tfsdk:"event_source_web_hook_sender"`
+	EventSourceScheduleCronExpression   types.String  `tfsdk:"event_source_schedule_cron_expression"`
+	EventSourceScheduleAttributionActor types.String  `tfsdk:"event_source_schedule_attribution_actor"`
+	EventPreset                         types.String  `tfsdk:"event_preset"`
+	EventName                           types.String  `tfsdk:"event_name"`
+	Disabled                            types.Bool    `tfsdk:"disabled"`
+	Parameters                          types.Dynamic `tfsdk:"parameters"`
 }
 
 // NewTriggerResource is a helper function to simplify the provider implementation.
@@ -156,11 +158,12 @@ func (r *triggerResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
 			},
-			"parameters": schema.MapAttribute{
-				MarkdownDescription: "Pipeline parameters to pass when running pipelines from this trigger. Only supported when `event_source_provider` is `schedule`.",
-				Optional:            true,
-				ElementType:         types.StringType,
-				PlanModifiers: []planmodifier.Map{
+			"parameters": schema.DynamicAttribute{
+				MarkdownDescription: "Pipeline parameters to pass when running pipelines from this trigger. Only supported when `event_source_provider` is `schedule`. " +
+					"Values may be strings, booleans, or numbers to match the type of the corresponding pipeline parameter, " +
+					"e.g. `parameters = { deploy_enabled = true, retries = 3, branch = \"main\" }`.",
+				Optional: true,
+				PlanModifiers: []planmodifier.Dynamic{
 					triggerParametersRequiresReplaceIfCleared{},
 				},
 			},
@@ -746,13 +749,66 @@ func isApiNotFoundError(err error) bool {
 	return strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found")
 }
 
-func triggerParametersToMap(ctx context.Context, parameters types.Map) (map[string]string, diag.Diagnostics) {
-	if parameters.IsNull() || parameters.IsUnknown() {
-		return nil, nil
+// triggerParametersToMap converts the dynamic `parameters` attribute into the
+// map[string]any the SDK sends to the API, preserving each value's JSON type
+// (string, boolean, or number) so typed pipeline parameters work correctly.
+func triggerParametersToMap(_ context.Context, parameters types.Dynamic) (map[string]any, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if parameters.IsNull() || parameters.IsUnknown() ||
+		parameters.IsUnderlyingValueNull() || parameters.IsUnderlyingValueUnknown() {
+		return nil, diags
 	}
-	out := make(map[string]string, len(parameters.Elements()))
-	diags := parameters.ElementsAs(ctx, &out, false)
+
+	obj, ok := parameters.UnderlyingValue().(types.Object)
+	if !ok {
+		diags.AddError(
+			"Invalid trigger parameters",
+			"parameters must be an object of string, boolean, or number values, "+
+				"e.g. { deploy_enabled = true, retries = 3, branch = \"main\" }",
+		)
+		return nil, diags
+	}
+
+	attrs := obj.Attributes()
+	out := make(map[string]any, len(attrs))
+	for k, v := range attrs {
+		native, d := triggerParameterValueToNative(k, v)
+		diags.Append(d...)
+		out[k] = native
+	}
+	if diags.HasError() {
+		return nil, diags
+	}
 	return out, diags
+}
+
+// triggerParameterValueToNative converts a single dynamic parameter value into a
+// Go native suitable for JSON encoding.
+func triggerParameterValueToNative(key string, v attr.Value) (any, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	switch val := v.(type) {
+	case types.String:
+		return val.ValueString(), diags
+	case types.Bool:
+		return val.ValueBool(), diags
+	case types.Number:
+		f := val.ValueBigFloat()
+		if f == nil {
+			return nil, diags
+		}
+		if f.IsInt() {
+			i, _ := f.Int64()
+			return i, diags
+		}
+		fl, _ := f.Float64()
+		return fl, diags
+	default:
+		diags.AddError(
+			"Unsupported trigger parameter type",
+			fmt.Sprintf("parameter %q must be a string, boolean, or number", key),
+		)
+		return nil, diags
+	}
 }
 
 // Forces replacement when parameters are cleared; PATCH can't unset them (SDK strips empty maps via omitempty).
@@ -766,24 +822,88 @@ func (m triggerParametersRequiresReplaceIfCleared) MarkdownDescription(ctx conte
 	return m.Description(ctx)
 }
 
-func (m triggerParametersRequiresReplaceIfCleared) PlanModifyMap(_ context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+func (m triggerParametersRequiresReplaceIfCleared) PlanModifyDynamic(_ context.Context, req planmodifier.DynamicRequest, resp *planmodifier.DynamicResponse) {
 	if req.StateValue.IsNull() || req.PlanValue.IsUnknown() {
 		return
 	}
-	hadValue := len(req.StateValue.Elements()) > 0
-	willBeEmpty := req.PlanValue.IsNull() || len(req.PlanValue.Elements()) == 0
+	hadValue := triggerParameterCount(req.StateValue) > 0
+	willBeEmpty := req.PlanValue.IsNull() || triggerParameterCount(req.PlanValue) == 0
 	if hadValue && willBeEmpty {
 		resp.RequiresReplace = true
 	}
 }
 
-func triggerParametersFromAPI(parameters map[string]string) (types.Map, diag.Diagnostics) {
+// triggerParameterCount returns the number of parameters held by a dynamic value,
+// or 0 when it is null/unknown or not an object.
+func triggerParameterCount(v types.Dynamic) int {
+	if v.IsNull() || v.IsUnknown() || v.IsUnderlyingValueNull() || v.IsUnderlyingValueUnknown() {
+		return 0
+	}
+	if obj, ok := v.UnderlyingValue().(types.Object); ok {
+		return len(obj.Attributes())
+	}
+	return 0
+}
+
+// triggerParametersFromAPI converts the API's free-form parameters map into the
+// dynamic `parameters` attribute, inferring an attribute type per value so the
+// stored object round-trips with the configuration.
+func triggerParametersFromAPI(parameters map[string]any) (types.Dynamic, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	if len(parameters) == 0 {
-		return types.MapNull(types.StringType), nil
+		return types.DynamicNull(), diags
 	}
-	elements := make(map[string]attr.Value, len(parameters))
+
+	attrTypes := make(map[string]attr.Type, len(parameters))
+	attrValues := make(map[string]attr.Value, len(parameters))
 	for k, v := range parameters {
-		elements[k] = types.StringValue(v)
+		value, typ, d := triggerParameterValueFromNative(k, v)
+		diags.Append(d...)
+		attrTypes[k] = typ
+		attrValues[k] = value
 	}
-	return types.MapValue(types.StringType, elements)
+	if diags.HasError() {
+		return types.DynamicNull(), diags
+	}
+
+	obj, d := types.ObjectValue(attrTypes, attrValues)
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.DynamicNull(), diags
+	}
+	return types.DynamicValue(obj), diags
+}
+
+// triggerParameterValueFromNative converts a single decoded JSON value into a
+// framework value and its matching attribute type.
+func triggerParameterValueFromNative(key string, v any) (attr.Value, attr.Type, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	switch val := v.(type) {
+	case string:
+		return types.StringValue(val), types.StringType, diags
+	case bool:
+		return types.BoolValue(val), types.BoolType, diags
+	case float64:
+		return types.NumberValue(big.NewFloat(val)), types.NumberType, diags
+	case int64:
+		return types.NumberValue(new(big.Float).SetInt64(val)), types.NumberType, diags
+	case int:
+		return types.NumberValue(new(big.Float).SetInt64(int64(val))), types.NumberType, diags
+	case json.Number:
+		f, _, err := big.ParseFloat(val.String(), 10, 512, big.ToNearestEven)
+		if err != nil {
+			diags.AddError(
+				"Invalid trigger parameter value",
+				fmt.Sprintf("parameter %q has a numeric value that could not be parsed: %s", key, err),
+			)
+			return nil, nil, diags
+		}
+		return types.NumberValue(f), types.NumberType, diags
+	default:
+		diags.AddError(
+			"Unsupported trigger parameter type",
+			fmt.Sprintf("parameter %q returned by the API is not a string, boolean, or number", key),
+		)
+		return nil, nil, diags
+	}
 }

--- a/internal/provider/trigger_resource_internal_test.go
+++ b/internal/provider/trigger_resource_internal_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) CircleCI
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestTriggerParametersRoundTrip verifies that typed pipeline parameters
+// (string, boolean, number) survive the conversion to the SDK's map[string]any
+// and back into the dynamic `parameters` attribute — the fix for issue #122.
+func TestTriggerParametersRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	obj, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"branch":         types.StringType,
+			"deploy_enabled": types.BoolType,
+			"retries":        types.NumberType,
+		},
+		map[string]attr.Value{
+			"branch":         types.StringValue("main"),
+			"deploy_enabled": types.BoolValue(false),
+			"retries":        types.NumberValue(big.NewFloat(3)),
+		},
+	)
+	if diags.HasError() {
+		t.Fatalf("building object: %v", diags)
+	}
+
+	apiParams, diags := triggerParametersToMap(ctx, types.DynamicValue(obj))
+	if diags.HasError() {
+		t.Fatalf("triggerParametersToMap: %v", diags)
+	}
+
+	if got, ok := apiParams["branch"].(string); !ok || got != "main" {
+		t.Errorf("branch = %#v, want string %q", apiParams["branch"], "main")
+	}
+	if got, ok := apiParams["deploy_enabled"].(bool); !ok || got != false {
+		t.Errorf("deploy_enabled = %#v, want bool false", apiParams["deploy_enabled"])
+	}
+	if got, ok := apiParams["retries"].(int64); !ok || got != 3 {
+		t.Errorf("retries = %#v, want int64 3", apiParams["retries"])
+	}
+
+	// The CircleCI API decodes JSON numbers as float64, so mirror that on the way back.
+	back, diags := triggerParametersFromAPI(map[string]any{
+		"branch":         "main",
+		"deploy_enabled": false,
+		"retries":        float64(3),
+	})
+	if diags.HasError() {
+		t.Fatalf("triggerParametersFromAPI: %v", diags)
+	}
+
+	backObj, ok := back.UnderlyingValue().(types.Object)
+	if !ok {
+		t.Fatalf("expected underlying object, got %T", back.UnderlyingValue())
+	}
+	if !backObj.Equal(obj) {
+		t.Errorf("round-trip mismatch:\n got: %#v\nwant: %#v", backObj, obj)
+	}
+}
+
+func TestTriggerParametersFromAPIEmptyIsNull(t *testing.T) {
+	got, diags := triggerParametersFromAPI(nil)
+	if diags.HasError() {
+		t.Fatalf("triggerParametersFromAPI: %v", diags)
+	}
+	if !got.IsNull() {
+		t.Errorf("expected null dynamic for empty parameters, got %#v", got)
+	}
+}
+
+func TestTriggerParametersToMapNull(t *testing.T) {
+	got, diags := triggerParametersToMap(context.Background(), types.DynamicNull())
+	if diags.HasError() {
+		t.Fatalf("triggerParametersToMap: %v", diags)
+	}
+	if got != nil {
+		t.Errorf("expected nil map for null parameters, got %#v", got)
+	}
+}

--- a/internal/provider/trigger_resource_test.go
+++ b/internal/provider/trigger_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"math/big"
 	"regexp"
 	"sort"
 	"strings"
@@ -161,7 +162,7 @@ func TestAccTriggerResourceScheduled(t *testing.T) {
 					pipelineName,
 					"0 * * * *",
 					false,
-					map[string]string{"run_nightly_foo": "true", "branch": "main"},
+					map[string]any{"run_nightly_foo": true, "retries": 3, "branch": "main"},
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -187,8 +188,9 @@ func TestAccTriggerResourceScheduled(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"circleci_trigger.test_trigger_scheduled",
 						tfjsonpath.New("parameters"),
-						knownvalue.MapExact(map[string]knownvalue.Check{
-							"run_nightly_foo": knownvalue.StringExact("true"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"run_nightly_foo": knownvalue.Bool(true),
+							"retries":         knownvalue.NumberExact(big.NewFloat(3)),
 							"branch":          knownvalue.StringExact("main"),
 						}),
 					),
@@ -200,7 +202,7 @@ func TestAccTriggerResourceScheduled(t *testing.T) {
 					pipelineName,
 					"0 12 * * *",
 					true,
-					map[string]string{"run_nightly_foo": "false", "branch": "main"},
+					map[string]any{"run_nightly_foo": false, "retries": 3, "branch": "main"},
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
@@ -216,8 +218,9 @@ func TestAccTriggerResourceScheduled(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"circleci_trigger.test_trigger_scheduled",
 						tfjsonpath.New("parameters"),
-						knownvalue.MapExact(map[string]knownvalue.Check{
-							"run_nightly_foo": knownvalue.StringExact("false"),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"run_nightly_foo": knownvalue.Bool(false),
+							"retries":         knownvalue.NumberExact(big.NewFloat(3)),
 							"branch":          knownvalue.StringExact("main"),
 						}),
 					),
@@ -314,7 +317,7 @@ func TestAccTriggerResourceWebhookRejectsParameters(t *testing.T) {
 					webhookTriggerName,
 					"61169e84-93ee-415d-8d65-ddf6dc0d2939",
 					"fefb451c-9966-4b75-b555-d4d94d7116ef",
-					map[string]string{"foo": "bar"},
+					map[string]any{"foo": "bar"},
 				),
 				ExpectError: regexp.MustCompile("does not support parameters"),
 			},
@@ -322,7 +325,7 @@ func TestAccTriggerResourceWebhookRejectsParameters(t *testing.T) {
 	})
 }
 
-func testAccTriggerResourceScheduledConfig(pipeline_name, cron_expression string, disabled bool, parameters map[string]string) string {
+func testAccTriggerResourceScheduledConfig(pipeline_name, cron_expression string, disabled bool, parameters map[string]any) string {
 	return fmt.Sprintf(`
 resource "circleci_pipeline" "test_pipeline_scheduled" {
   project_id                       = "61169e84-93ee-415d-8d65-ddf6dc0d2939"
@@ -349,7 +352,7 @@ resource "circleci_trigger" "test_trigger_scheduled" {
 `, pipeline_name, cron_expression, disabled, renderParametersHCL(parameters))
 }
 
-func renderParametersHCL(parameters map[string]string) string {
+func renderParametersHCL(parameters map[string]any) string {
 	if len(parameters) == 0 {
 		return ""
 	}
@@ -361,7 +364,13 @@ func renderParametersHCL(parameters map[string]string) string {
 	var b strings.Builder
 	b.WriteString("  parameters = {\n")
 	for _, k := range keys {
-		fmt.Fprintf(&b, "    %q = %q\n", k, parameters[k])
+		switch v := parameters[k].(type) {
+		case string:
+			fmt.Fprintf(&b, "    %q = %q\n", k, v)
+		default:
+			// bool and numeric values render unquoted so Terraform preserves their type.
+			fmt.Fprintf(&b, "    %q = %v\n", k, v)
+		}
 	}
 	b.WriteString("  }\n")
 	return b.String()
@@ -409,7 +418,7 @@ resource "circleci_trigger" "test_trigger_github" {
 `, project_id, pipeline_id)
 }
 
-func testAccTriggerResourceWebhookConfig(event_name, project_id, pipeline_id string, parameters map[string]string) string {
+func testAccTriggerResourceWebhookConfig(event_name, project_id, pipeline_id string, parameters map[string]any) string {
 	return fmt.Sprintf(`
 resource "circleci_trigger" "test_trigger_webhook" {
   event_name				= %[1]q

--- a/templates/resources/trigger.md.tmpl
+++ b/templates/resources/trigger.md.tmpl
@@ -35,8 +35,12 @@ resource "circleci_trigger" "scheduled" {
   config_ref                               = "main"
   event_source_schedule_cron_expression    = "0 2 * * *"
   event_source_schedule_attribution_actor  = "system"
-  parameters                               = {
-    run_nightly_foo = "true"
+
+  # Parameter values may be strings, booleans, or numbers to match the type of
+  # the corresponding pipeline parameter.
+  parameters = {
+    run_nightly_foo = true
+    retries         = 3
     branch          = "main"
   }
 }


### PR DESCRIPTION
Change the trigger `parameters` attribute from a Map of String to a Dynamic attribute so scheduled triggers can pass boolean and numeric pipeline parameters, not just strings. Bumps circleci-sdk-go to the version where Trigger.Parameters is map[string]any, updates the resource and data source conversion helpers to preserve JSON types both ways, and refreshes tests, docs, and examples.

Fixes #122